### PR TITLE
Added feature: remember + max_validation_try_count: useful if you doesn'...

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,6 +26,8 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('private_key')->isRequired()->end()
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->booleanNode('ajax')->defaultFalse()->end()
+                ->booleanNode('remember')->defaultFalse()->end()
+                ->scalarNode('max_validation_try_count')->defaultValue(5)->end()
                 ->scalarNode('locale_key')->defaultValue('%kernel.default_locale%')->end()
             ->end()
         ;

--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ ewz_recaptcha:
     public_key:  here_is_your_public_key
     private_key: here_is_your_private_key
     locale_key:  %kernel.default_locale%
+    remember:  false
+    max_validation_try_count:  5
 ```
+
+`remember` is useful if you doesn't want to display the reCaptcha field when the user already passed validation before (using server session)
+
+`max_validation_try_count` is the number of time a user can validate a reCaptcha form without having captcha displayed/checked if already validated once (only working if `remember: true`)
 
 **NOTE**: This Bundle lets the client browser choose the secure https or unsecure http API.
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,6 +16,9 @@
             <argument>%ewz_recaptcha.enabled%</argument>
             <argument>%ewz_recaptcha.ajax%</argument>
             <argument>%ewz_recaptcha.locale_key%</argument>
+            <argument type="service" id="session" />
+            <argument>%ewz_recaptcha.remember%</argument>
+            <argument>%ewz_recaptcha.max_validation_try_count%</argument>
         </service>
 
         <service id="ewz_recaptcha.validator.true" class="%ewz_recaptcha.validator.true.class%">
@@ -23,6 +26,9 @@
             <argument>%ewz_recaptcha.enabled%</argument>
             <argument>%ewz_recaptcha.private_key%</argument>
             <argument type="service" id="request_stack" />
+            <argument type="service" id="session" />
+            <argument>%ewz_recaptcha.remember%</argument>
+            <argument>%ewz_recaptcha.max_validation_try_count%</argument>
         </service>
     </services>
 </container>

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "excelwebzone/recaptcha-bundle",
-    "description": "This bundle provides easy reCAPTCHA form field integration",
+    "name": "lethak/EWZRecaptchaBundle ",
+    "description": "This bundle provides easy reCAPTCHA form field integration (forked from excelwebzone) ",
     "keywords": ["recaptcha"],
-    "homepage": "https://github.com/excelwebzone/EWZRecaptchaBundle",
+    "homepage": "https://github.com/lethak/EWZRecaptchaBundle",
     "type": "symfony-bundle",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lethak/EWZRecaptchaBundle ",
+    "name": "lethak/excelwebzonerecaptcha-bundle",
     "description": "This bundle provides easy reCAPTCHA form field integration (forked from excelwebzone) ",
     "keywords": ["recaptcha"],
     "homepage": "https://github.com/lethak/EWZRecaptchaBundle",


### PR DESCRIPTION
### Added feature in config:

`remember` + `max_validation_try_count`

Useful if you doesn't want to display the reCaptcha field when the user already passed validation before

Tested and working with symfony v2.5.10