### PR TITLE
Make widget form language configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -26,7 +26,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('private_key')->isRequired()->end()
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->booleanNode('ajax')->defaultFalse()->end()
-                ->scalarNode('locale_key')->defaultValue('%kernel.default_locale%')->end()
+                ->scalarNode('default_locale_key')->defaultValue('%kernel.default_locale%')->end()
             ->end()
         ;
 

--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * A field for entering a recaptcha text.
@@ -44,21 +45,21 @@ class RecaptchaType extends AbstractType
      *
      * @var string
      */
-    protected $language;
+    protected $defaultLanguage;
 
     /**
      * Construct.
      *
      * @param string  $publicKey Recaptcha public key
      * @param Boolean $enabled Recaptache status
-     * @param string  $language language or locale code
+     * @param string  $defaultLanguage language or locale code
      */
-    public function __construct($publicKey, $enabled, $ajax, $language)
+    public function __construct($publicKey, $enabled, $ajax, $defaultLanguage)
     {
         $this->publicKey = $publicKey;
         $this->enabled   = $enabled;
         $this->ajax      = $ajax;
-        $this->language  = $language;
+        $this->defaultLanguage  = $defaultLanguage;
     }
 
     /**
@@ -77,7 +78,7 @@ class RecaptchaType extends AbstractType
 
         if (!$this->ajax) {
             $view->vars = array_replace($view->vars, array(
-                'url_challenge' => sprintf('%s?hl=%s', self::RECAPTCHA_API_SERVER, $this->language),
+                'url_challenge' => sprintf('%s?hl=%s', self::RECAPTCHA_API_SERVER, $options['language']),
                 'public_key'    => $this->publicKey,
             ));
         } else {
@@ -88,24 +89,23 @@ class RecaptchaType extends AbstractType
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function configureOptions(OptionsResolver $resolver)
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(array(
             'compound'      => false,
             'public_key'    => null,
             'url_challenge' => null,
             'url_noscript'  => null,
+            'language'      => $this->defaultLanguage,
             'attr'          => array(
                 'options' => array(
                     'theme' => 'light',
-                    'type'  => 'image'
+                    'type'  => 'image',
                 )
             )
         ));
     }
+
 
     /**
      * {@inheritdoc}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add the following to your config file:
 ewz_recaptcha:
     public_key:  here_is_your_public_key
     private_key: here_is_your_private_key
-    locale_key:  %kernel.default_locale%
+    default_locale_key:  %kernel.default_locale%
 ```
 
 **NOTE**: This Bundle lets the client browser choose the secure https or unsecure http API.
@@ -115,6 +115,22 @@ public function buildForm(FormBuilder $builder, array $options)
                 'type'  => 'image'
             )
         )
+    ));
+    // ...
+}
+```
+
+If you need to configure the language of the captcha depending on your site language (multisite languages) you can pass the language with the "language" option:
+
+``` php
+<?php
+
+public function buildForm(FormBuilder $builder, array $options)
+{
+    // ...
+    $builder->add('recaptcha', 'ewz_recaptcha', array(
+        'language' => 'en'
+        // ...
     ));
     // ...
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,7 +15,7 @@
             <argument>%ewz_recaptcha.public_key%</argument>
             <argument>%ewz_recaptcha.enabled%</argument>
             <argument>%ewz_recaptcha.ajax%</argument>
-            <argument>%ewz_recaptcha.locale_key%</argument>
+            <argument>%ewz_recaptcha.default_locale_key%</argument>
         </service>
 
         <service id="ewz_recaptcha.validator.true" class="%ewz_recaptcha.validator.true.class%">


### PR DESCRIPTION
This PR adds a way to configure in which language the captcha widget is displayed. 

Altough the language is set in the bundle config sometimes you need to specify the language depending on the site locale (multilanguage sites).