### PR TITLE
Update minimmum Symfony Framework version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.4"
+        "symfony/framework-bundle": "~2.7"
     },
     "autoload": {
         "psr-0": { "EWZ\\Bundle\\RecaptchaBundle\\": "" }


### PR DESCRIPTION
Due to tue usage of configureOptions function in the EWZ\Bundle\RecaptchaBundle\Form\Type\Type class, the minimmum required version for this bundle to work is 2.7.