### PR TITLE
Fix Bridge for Silex: translator and proxy

### DIFF
--- a/Bridge/RecaptchaServiceProvider.php
+++ b/Bridge/RecaptchaServiceProvider.php
@@ -23,6 +23,11 @@ class RecaptchaServiceProvider implements ServiceProviderInterface
         $app['ewz_recaptcha.locale_key'] = $app['locale'];
         $app['ewz_recaptcha.enabled'] = true;
         $app['ewz_recaptcha.ajax'] = false;
+        $app['ewz_recaptcha.http_proxy'] = array(
+            'host' => null,
+            'port' => null,
+            'auth' => null,
+        );
 
         // add loader for EWZ Template
         if (isset($app['twig'])) {
@@ -51,7 +56,8 @@ class RecaptchaServiceProvider implements ServiceProviderInterface
                 $validator = new IsTrueValidator(
                     $app['ewz_recaptcha.enabled'],
                     $app['ewz_recaptcha.private_key'],
-                    $app['request_stack']
+                    $app['request_stack'],
+                    $app['ewz_recaptcha.http_proxy']
                 );
 
                 return $validator;
@@ -67,12 +73,16 @@ class RecaptchaServiceProvider implements ServiceProviderInterface
 
         // Register translation files
         if (isset($app['translator'])) {
-            $app['translator']->addResource(
-                'xliff',
-                dirname(__FILE__).'/../Resources/translations/validators.'.$app['locale'].'.xlf',
-                $app['locale'],
-                'validators'
-            );
+            $app['translator'] = $app->share($app->extend('translator', function($translator, $app) {
+                $translator->addResource(
+                    'xliff',
+                    dirname(__FILE__).'/../Resources/translations/validators.'.$app['ewz_recaptcha.locale_key'].'.xlf',
+                    $app['ewz_recaptcha.locale_key'],
+                    'validators'
+                );
+
+                return $translator;
+            }));
         }
     }
 

--- a/Validator/Constraints/IsTrueValidator.php
+++ b/Validator/Constraints/IsTrueValidator.php
@@ -44,9 +44,12 @@ class IsTrueValidator extends ConstraintValidator
     /**
      * Construct.
      *
-     * @param ContainerInterface $container An ContainerInterface instance
+     * @param Boolean $enabled
+     * @param string $privateKey
+     * @param RequestStack $requestStack
+     * @param array $httpProxy
      */
-    public function __construct($enabled, $privateKey, RequestStack $requestStack, array $httpProxy = array())
+    public function __construct($enabled, $privateKey, RequestStack $requestStack, array $httpProxy)
     {
         $this->enabled = $enabled;
         $this->privateKey = $privateKey;


### PR DESCRIPTION
Hello,


First, the translator didn't took the real 'locale' as when the provider was load, the configuration of $app['locale'] or $app['ewz_recaptcha.locale_key'] wasn't set yet, or only by default ("en").


Second, the previous 'fix' for Silex Bridge was'nt enough, as it didn't took into account that $httproxy, tested in the method 'getResourceContext()' of the IsTrueValidor class, was assumed to have a 'host' and 'port' key. Having an empty array still raised a notice message about keys 'host' and 'port'.
Putting a default value for the $app['ewz_recaptcha.http_proxy'] variable and using it fixed it.

It's more a double fix, and I can split it in two if needed.

Thanks for the works on this bundle :)

