### PR TITLE
Readme: Add full `RecaptchaType` class namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ When creating a new form class add the following line to create the field:
 ``` php
 <?php
 
+use EWZ\Bundle\RecaptchaBundle\Form\Type\RecaptchaType as EWZRecaptchaType;
+
 public function buildForm(FormBuilder $builder, array $options)
 {
     // ...


### PR DESCRIPTION
After copy-paste from Readme, autocompletion fails with `EWZRecaptchaType`, so either add full namespace or using good class name `RecaptchaType` is less confusing.