### PR TITLE
Add missing git ignores for composer files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+### Composer
+/vendor/
+composer.lock
+composer.phar


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Adds `composer.lock` and the `vendor` dir and `composer.phar` to be ignored by git.

#### Why?

Those files should always be ignored, otherwise people may commit them to git. Especially for beginners this could be confusing/annoying.
