### PR TITLE
Add missing documentation for the language option on the form type

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,24 @@ public function buildForm(FormBuilder $builder, array $options)
 }
 ```
 
+If you need to configure the language of the captcha depending on your site
+language (multisite languages) you can pass the language with the "language"
+option:
+
+``` php
+<?php
+
+public function buildForm(FormBuilder $builder, array $options)
+{
+    // ...
+    $builder->add('recaptcha', 'ewz_recaptcha', array(
+        'language' => 'en'
+        // ...
+    ));
+    // ...
+}
+```
+
 To validate the field use:
 
 ``` php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | partially #89 
| Related issues/PRs | #56, #61, #67
| License | MIT

#### What's in this PR?

Adds the missing documentation for the added language option on the form type, added in #67. The documentation is originated from #56 by @solilokiam, who originally wanted to add the language option, thus the attribution with the changed author in the commit.

#### Why?

As you can see in #89, it's not really known that the language option is available on the form type.
