### PR TITLE
Add resolver to dynamically use the locale from the current request

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('enabled')->defaultTrue()->end()
                 ->booleanNode('ajax')->defaultFalse()->end()
                 ->scalarNode('locale_key')->defaultValue('%kernel.default_locale%')->end()
+                ->booleanNode('locale_from_request')->defaultFalse()->end()
             ->end()
         ;
 

--- a/Form/Type/EWZRecaptchaType.php
+++ b/Form/Type/EWZRecaptchaType.php
@@ -2,6 +2,7 @@
 
 namespace EWZ\Bundle\RecaptchaBundle\Form\Type;
 
+use EWZ\Bundle\RecaptchaBundle\Locale\LocaleResolver;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -41,11 +42,9 @@ class EWZRecaptchaType extends AbstractType
     protected $ajax;
 
     /**
-     * Language
-     *
-     * @var string
+     * @var LocaleResolver
      */
-    protected $language;
+    protected $localeResolver;
 
     /**
      * Construct.
@@ -53,14 +52,14 @@ class EWZRecaptchaType extends AbstractType
      * @param string  $publicKey Recaptcha public key
      * @param Boolean $enabled   Recaptache status
      * @param Boolean $ajax      Ajax status
-     * @param string  $language  Language or locale code
+     * @param string  $localeResolver
      */
-    public function __construct($publicKey, $enabled, $ajax, $language)
+    public function __construct($publicKey, $enabled, $ajax, $localeResolver)
     {
         $this->publicKey = $publicKey;
         $this->enabled   = $enabled;
         $this->ajax      = $ajax;
-        $this->language  = $language;
+        $this->localeResolver  = $localeResolver;
     }
 
     /**
@@ -78,7 +77,7 @@ class EWZRecaptchaType extends AbstractType
         }
 
         if (!isset($options['language'])) {
-            $options['language'] = $this->language;
+            $options['language'] = $this->localeResolver->resolve();
         }
 
         if (!$this->ajax) {
@@ -101,7 +100,7 @@ class EWZRecaptchaType extends AbstractType
     {
         $resolver->setDefaults(array(
             'compound'      => false,
-            'language'      => $this->language,
+            'language'      => $this->localeResolver->resolve(),
             'public_key'    => null,
             'url_challenge' => null,
             'url_noscript'  => null,

--- a/Locale/LocaleResolver.php
+++ b/Locale/LocaleResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EWZ\Bundle\RecaptchaBundle\Locale;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Depending on the configuration resolves the correct locale
+ * for the reCAPTCHA.
+ *
+ * @author Patrik Karisch <patrik@karisch.guru>
+ */
+final class LocaleResolver
+{
+    /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
+     * @var bool
+     */
+    private $useLocaleFromRequest;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @param string       $defaultLocale
+     * @param bool         $useLocaleFromRequest
+     * @param RequestStack $requestStack
+     */
+    public function __construct($defaultLocale, $useLocaleFromRequest, RequestStack $requestStack)
+    {
+        $this->defaultLocale = $defaultLocale;
+        $this->useLocaleFromRequest = $useLocaleFromRequest;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @return string The resolved locale key, depending on configuration
+     */
+    public function resolve()
+    {
+        return $this->useLocaleFromRequest
+            ? $this->requestStack->getCurrentRequest()->getLocale()
+            : $this->defaultLocale;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,10 +40,22 @@ Add the following to your config file:
 ewz_recaptcha:
     public_key:  here_is_your_public_key
     private_key: here_is_your_private_key
+    # Not needed as "%kernel.default_locale%" is the default value for the locale key
     locale_key:  %kernel.default_locale%
 ```
 
 **NOTE**: This Bundle lets the client browser choose the secure https or unsecure http API.
+
+If you want to use the language default for the reCAPTCHA the same as the
+request locale you must activate the resolver (deactivated by default):
+
+``` yaml
+# app/config/config.yml
+
+ewz_recaptcha:
+    // ...
+    locale_from_request: true
+```
 
 You can easily disable reCAPTCHA (for example in a local or test environment):
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,11 +1,19 @@
 services:
+    ewz_recaptcha.locale.resolver:
+        class: EWZ\Bundle\RecaptchaBundle\Locale\LocaleResolver
+        public: false
+        arguments:
+            - '%ewz_recaptcha.locale_key%'
+            - '%ewz_recaptcha.locale_from_request%'
+            - '@request_stack'
+
     ewz_recaptcha.form.type:
         class: EWZ\Bundle\RecaptchaBundle\Form\Type\EWZRecaptchaType
         arguments:
             - '%ewz_recaptcha.public_key%'
             - '%ewz_recaptcha.enabled%'
             - '%ewz_recaptcha.ajax%'
-            - '%ewz_recaptcha.locale_key%'
+            - '@ewz_recaptcha.locale.resolver'
         tags:
             - { name: form.type }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | internally
| Deprecations? | no
| Fixed tickets | fixes #89 
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Add resolver to dynamically use the locale from the current request.

#### Why?

It's annoying to set in in every form via the request stack by ourself :yum:

#### Example Usage

Simple activation in the config needed, so it does not change behaviour in existing installations:

``` yaml
# app/config/config.yml

ewz_recaptcha:
    // ...
    locale_from_request: true
```

#### BC Breaks

It breaks only if anyone extended the `EWZRecaptchaType` and used `$this->language` like the code snippet in #89. Should be not a problem, because such a hack should break and force the user to better code quality :neckbeard:

#### Version considerations

Regarding the BC break is not exposed in public API and the feature must be activated to be used, this can go in a minor release.
