### PR TITLE
Add missing composer deps (symfony forms and validator components)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,9 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~2.8|~3.0"
+        "symfony/form": "^2.8 || ^3.0",
+        "symfony/validator": "^2.8 || ^3.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0"
     },
     "autoload": {
         "psr-4": { "EWZ\\Bundle\\RecaptchaBundle\\": "" }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no 
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

Adds the missing composer deps to the `composer.json`. Normally it has no effect, because a bundle installed in a not `symfony/symfony` requiring project may be a rare edge case, but I know about such cases ;)

#### Why?

And it's annoying while developing if not all deps/namespaces/classes can be resolved in the IDE :grin: