### PR TITLE
new config: remember_max_count + session variable reCaptcha.isNotARobot

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('ajax')->defaultFalse()->end()
                 ->scalarNode('locale_key')->defaultValue('%kernel.default_locale%')->end()
                 ->booleanNode('locale_from_request')->defaultFalse()->end()
+                ->scalarNode('remember_max_count')->defaultValue(0)->end()
             ->end()
         ;
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ ewz_recaptcha:
     port: 3128
     auth: proxy_username:proxy_password
 ```
+You can remember if the captcha was already validated and not again requiring it for a certain number of time (default: 0):
+
+``` yaml
+# app/config/config.yml
+
+ewz_recaptcha:
+    // ...
+    remember_max_count: 5
+```
 
 Congratulations! You're ready!
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,6 +14,8 @@ services:
             - '%ewz_recaptcha.enabled%'
             - '%ewz_recaptcha.ajax%'
             - '@ewz_recaptcha.locale.resolver'
+            - '@session'
+            - '%ewz_recaptcha.remember_max_count%'
         tags:
             - { name: form.type }
 
@@ -24,5 +26,7 @@ services:
                 - '%ewz_recaptcha.private_key%'
                 - '@request_stack'
                 - '%ewz_recaptcha.http_proxy%'
+                - '@session'
+                - '%ewz_recaptcha.remember_max_count%'
             tags:
                 - { name: validator.constraint_validator, alias: 'ewz_recaptcha.true' }

--- a/Validator/Constraints/IsTrueValidator.php
+++ b/Validator/Constraints/IsTrueValidator.php
@@ -85,7 +85,7 @@ class IsTrueValidator extends ConstraintValidator
         $this->session->set('reCaptcha.rememberTryCount', $rememberTryCount);
 
         // if recaptcha is disabled, always valid
-        if (!$this->enabled || ($this->rememberMaxCount && $this->session->get('reCaptcha.isNotARobot') && $rememberTryCount <= $this->maxValidationTryCount) ) {
+        if (!$this->enabled || ($this->rememberMaxCount && $this->session->get('reCaptcha.isNotARobot') && $rememberTryCount <= $this->rememberMaxCount) ) {
             return;
         }
 


### PR DESCRIPTION
This adds a config option "remember_max_count" (int, default: 0)

For example, if set to 5, the recaptcha will be hidden/not required for 5 consecutive submissions following a valid one.

This adds session variable to allow re-use of the result:  $session->get('reCaptcha.isNotARobot')
