### PR TITLE
restore bc to 2.8 and lower for form type names

### DIFF
--- a/Form/Type/EWZRecaptchaType.php
+++ b/Form/Type/EWZRecaptchaType.php
@@ -126,6 +126,14 @@ class EWZRecaptchaType extends AbstractType
     }
 
     /**
+     * @deprecated since 1.4.2 and will be removed in 2.0. guarantees backward compatibility to 2.8 and lower.
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getBlockPrefix()


### PR DESCRIPTION
Hey,

since version 1.4.2 you destroyed bc to symfony 2.8.
In 2.8 is getting form type by name deprecated but NOT removed.

I did restore it.

Perhaps you want to read this (http://symfony.com/doc/current/contributing/code/bc.html) and this (https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md)

Greetings
