### PR TITLE
Add callback attribute support

### DIFF
--- a/Form/Type/EWZRecaptchaType.php
+++ b/Form/Type/EWZRecaptchaType.php
@@ -109,6 +109,7 @@ class EWZRecaptchaType extends AbstractType
                     'theme'           => 'light',
                     'type'            => 'image',
                     'size'            => 'normal',
+                    'callback'        => null,
                     'expiredCallback' => null,
                     'defer'           => false,
                     'async'           => false,

--- a/Resources/views/Form/ewz_recaptcha_widget.html.php
+++ b/Resources/views/Form/ewz_recaptcha_widget.html.php
@@ -1,7 +1,7 @@
 <?php if ($ewz_recaptcha_enabled): ?>
     <?php if (!$ewz_recaptcha_ajax): ?>
         <script src="<?php echo $url_challenge ?>" type="text/javascript"></script>
-        <div class="g-recaptcha" data-theme="<?php echo $attr['options']['theme'] ?>" data-size="<?php echo $attr['options']['size'] ?>" data-type="<?php echo $attr['options']['type'] ?>" data-sitekey="<?php echo $public_key ?>"  <?php if (isset($attr['options']['expiredCallback'])): ?>data-expired-callback="<?php echo $attr['options']['expiredCallback'] ?>"<?php endif ?>></div>
+        <div class="g-recaptcha" data-theme="<?php echo $attr['options']['theme'] ?>" data-size="<?php echo $attr['options']['size'] ?>" data-type="<?php echo $attr['options']['type'] ?>" data-sitekey="<?php echo $public_key ?>" <?php if (isset($attr['options']['callback'])): ?>data-callback="<?php echo $attr['options']['callback'] ?>"<?php endif ?> <?php if (isset($attr['options']['expiredCallback'])): ?>data-expired-callback="<?php echo $attr['options']['expiredCallback'] ?>"<?php endif ?>></div>
         <noscript>
             <div style="width: 302px; height: 352px;">
                 <div style="width: 302px; height: 352px; position: relative;">

--- a/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -2,12 +2,14 @@
 {% spaceless %}
     {% if form.vars.ewz_recaptcha_enabled %}
         {% if not form.vars.ewz_recaptcha_ajax %}
-            <script type="text/javascript"
-                src="{{ form.vars.url_challenge }}"
-                {% if attr.options.defer is defined and attr.options.defer %}defer{% endif %}
-                {% if attr.options.async is defined and attr.options.async %}async{% endif %}
+            <script type="text/javascript" src="{{ form.vars.url_challenge }}"
+                {%- if attr.options.defer is defined and attr.options.defer %} defer{% endif -%}
+                {%- if attr.options.async is defined and attr.options.async %} async{% endif -%}
             ></script>
-            <div class="g-recaptcha" data-theme="{{ attr.options.theme }}" data-size="{{ attr.options.size }}" data-type="{{ attr.options.type }}" data-sitekey="{{ form.vars.public_key }}" {% if attr.options.expiredCallback is defined %}data-expired-callback="{{ attr.options.expiredCallback }}"{% endif %}></div>
+            <div class="g-recaptcha" data-theme="{{ attr.options.theme }}" data-size="{{ attr.options.size }}" data-type="{{ attr.options.type }}" data-sitekey="{{ form.vars.public_key }}"
+                 {%- if attr.options.callback is defined %} data-callback="{{ attr.options.callback }}"{% endif -%}
+                 {%- if attr.options.expiredCallback is defined %} data-expired-callback="{{ attr.options.expiredCallback }}"{% endif -%}
+            ></div>
             <noscript>
                 <div style="width: 302px; height: 352px;">
                     <div style="width: 302px; height: 352px; position: relative;">


### PR DESCRIPTION
Closes #105

https://developers.google.com/recaptcha/docs/display#render_param
`data-callback` Optional. The name of your callback function to be executed when the user submits a successful CAPTCHA response. The user's response, g-recaptcha-response, will be the input for your callback function.

I also added some whitespace control between attributes.