### PR TITLE
Set httpGet method to protected to make it overridable

### DIFF
--- a/Validator/Constraints/IsTrueValidator.php
+++ b/Validator/Constraints/IsTrueValidator.php
@@ -92,6 +92,24 @@ class IsTrueValidator extends ConstraintValidator
             $this->context->addViolation($constraint->message);
         }
     }
+    
+    /**
+     * Submits an HTTP POST to a reCAPTCHA server.
+     *
+     * @param string $host
+     * @param string $path
+     * @param array  $data
+     *
+     * @return array response
+     */
+    protected function httpGet($host, $path, $data)
+    {
+        $host = sprintf('%s%s?%s', $host, $path, http_build_query($data));
+
+        $context = $this->getResourceContext();
+
+        return file_get_contents($host, false, $context);
+    }
 
     /**
       * Calls an HTTP POST function to verify if the user's guess was correct.
@@ -122,24 +140,6 @@ class IsTrueValidator extends ConstraintValidator
         ));
 
         return json_decode($response, true);
-    }
-
-    /**
-     * Submits an HTTP POST to a reCAPTCHA server.
-     *
-     * @param string $host
-     * @param string $path
-     * @param array  $data
-     *
-     * @return array response
-     */
-    private function httpGet($host, $path, $data)
-    {
-        $host = sprintf('%s%s?%s', $host, $path, http_build_query($data));
-
-        $context = $this->getResourceContext();
-
-        return file_get_contents($host, false, $context);
     }
 
     private function getResourceContext()


### PR DESCRIPTION
Hi,

I cannot use the httpGet method you provided because of my security policy that turns off "allow_url_fopen" in the php.ini.

I'd like to use CURL to make the request, but the method is private so I have almost to copy paste the whole class to override the few lines of httpGet and make it with my own http client.

I propose to make this method protected so that anyone can override it easily and use the http client they like.