### PR TITLE
Added support for multiple captchas and dynamic initialization

### DIFF
--- a/Form/Type/EWZRecaptchaType.php
+++ b/Form/Type/EWZRecaptchaType.php
@@ -113,6 +113,8 @@ class EWZRecaptchaType extends AbstractType
                     'expiredCallback' => null,
                     'defer'           => false,
                     'async'           => false,
+                    'renderExplicit'  => false,
+                    'renderId'        => null,
                 )
             )
         ));

--- a/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -1,53 +1,74 @@
 {% block ewz_recaptcha_widget %}
-{% spaceless %}
-    {% if form.vars.ewz_recaptcha_enabled %}
-        {% if not form.vars.ewz_recaptcha_ajax %}
-            <script type="text/javascript" src="{{ form.vars.url_challenge }}"
-                {%- if attr.options.defer is defined and attr.options.defer %} defer{% endif -%}
-                {%- if attr.options.async is defined and attr.options.async %} async{% endif -%}
-            ></script>
-            <div class="g-recaptcha" data-theme="{{ attr.options.theme }}" data-size="{{ attr.options.size }}" data-type="{{ attr.options.type }}" data-sitekey="{{ form.vars.public_key }}"
-                 {%- if attr.options.callback is defined %} data-callback="{{ attr.options.callback }}"{% endif -%}
-                 {%- if attr.options.expiredCallback is defined %} data-expired-callback="{{ attr.options.expiredCallback }}"{% endif -%}
-            ></div>
-            <noscript>
-                <div style="width: 302px; height: 352px;">
-                    <div style="width: 302px; height: 352px; position: relative;">
-                        <div style="width: 302px; height: 352px; position: absolute;">
-                            <iframe src="https://www.google.com/recaptcha/api/fallback?k={{ form.vars.public_key }}"
-                                    frameborder="0" scrolling="no"
-                                    style="width: 302px; height:352px; border-style: none;"
-                            >
-                            </iframe>
-                        </div>
-                        <div style="width: 250px; height: 80px; position: absolute; border-style: none; bottom: 21px; left: 25px; margin: 0; padding: 0; right: 25px;">
+    {% spaceless %}
+        {% if form.vars.ewz_recaptcha_enabled %}
+            {% if not form.vars.ewz_recaptcha_ajax %}
+                {%- if attr.options.renderExplicit is defined and attr.options.renderExplicit %}
+                    {% set uuid = attr.options.renderId %}
+                    <script>
+                        // Load the library only the first time
+                        if (typeof grecaptcha == 'undefined') {
+                            var el = document.createElement('script');
+                            document.body.appendChild(el);
+                            el.onload = function (script) {
+                                grecaptcha.render('recaptcha-{{ uuid }}', {'sitekey': '{{ form.vars.public_key }}'});
+                            };
+                            el.src = "{{ form.vars.url_challenge }}}&render=explicit {%- if attr.options.defer is defined and attr.options.defer %} defer{% endif -%} {%- if attr.options.async is defined and attr.options.async %} async{% endif -%}";
+                        } else {
+                            grecaptcha.render('recaptcha-{{ uuid }}', {'sitekey': '{{ form.vars.public_key }}'});
+                        }
+                    </script>
+
+                    <div id="recaptcha-{{ uuid }}" class="g-recaptcha" data-theme="{{ attr.options.theme }}" data-size="{{ attr.options.size }}" data-type="{{ attr.options.type }}" data-sitekey="{{ form.vars.public_key }}"
+                            {%- if attr.options.callback is defined %} data-callback="{{ attr.options.callback }}"{% endif -%}
+                            {%- if attr.options.expiredCallback is defined %} data-expired-callback="{{ attr.options.expiredCallback }}"{% endif -%}
+                    ></div>
+                {% else %}
+                <script type="text/javascript" src="{{ form.vars.url_challenge }}"
+                        {%- if attr.options.defer is defined and attr.options.defer %} defer{% endif -%}
+                        {%- if attr.options.async is defined and attr.options.async %} async{% endif -%}
+                ></script>
+                <div class="g-recaptcha" data-theme="{{ attr.options.theme }}" data-size="{{ attr.options.size }}" data-type="{{ attr.options.type }}" data-sitekey="{{ form.vars.public_key }}"
+                        {%- if attr.options.callback is defined %} data-callback="{{ attr.options.callback }}"{% endif -%}
+                        {%- if attr.options.expiredCallback is defined %} data-expired-callback="{{ attr.options.expiredCallback }}"{% endif -%}
+                ></div>
+                {% endif -%}
+                <noscript>
+                    <div style="width: 302px; height: 352px;">
+                        <div style="width: 302px; height: 352px; position: relative;">
+                            <div style="width: 302px; height: 352px; position: absolute;">
+                                <iframe src="https://www.google.com/recaptcha/api/fallback?k={{ form.vars.public_key }}"
+                                        frameborder="0" scrolling="no"
+                                        style="width: 302px; height:352px; border-style: none;"
+                                >
+                                </iframe>
+                            </div>
+                            <div style="width: 250px; height: 80px; position: absolute; border-style: none; bottom: 21px; left: 25px; margin: 0; padding: 0; right: 25px;">
                             <textarea id="g-recaptcha-response" name="g-recaptcha-response"
                                       class="g-recaptcha-response"
                                       style="width: 250px; height: 80px; border: 1px solid #c1c1c1; margin: 0; padding: 0; resize: none;"
                             >
                             </textarea>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </noscript>
-        {% else %}
-            <div id="ewz_recaptcha_div"></div>
+                </noscript>
+            {% else %}
+                <div id="ewz_recaptcha_div"></div>
 
-            <script type="text/javascript">
-            (function() {
-                var script = document.createElement('script');
-                script.type = 'text/javascript';
-                script.onload = function() {
-                    Recaptcha.create('{{ form.vars.public_key }}', 'ewz_recaptcha_div', {{ attr.options|default({})|json_encode|raw }});
-                };
-                script.src = '{{ form.vars.url_api }}';
-                {% if attr.options.defer is defined and attr.options.defer %}script.defer = true;{% endif %}
-                {% if attr.options.async is defined and attr.options.async %}script.async = true;{% endif %}
-                document.getElementsByTagName('head')[0].appendChild(script);
-            })();
-            </script>
+                <script type="text/javascript">
+                    (function() {
+                        var script = document.createElement('script');
+                        script.type = 'text/javascript';
+                        script.onload = function() {
+                            Recaptcha.create('{{ form.vars.public_key }}', 'ewz_recaptcha_div', {{ attr.options|default({})|json_encode|raw }});
+                        };
+                        script.src = '{{ form.vars.url_api }}';
+                        {% if attr.options.defer is defined and attr.options.defer %}script.defer = true;{% endif %}
+                        {% if attr.options.async is defined and attr.options.async %}script.async = true;{% endif %}
+                        document.getElementsByTagName('head')[0].appendChild(script);
+                    })();
+                </script>
+            {% endif %}
         {% endif %}
-    {% endif %}
-{% endspaceless %}
+    {% endspaceless %}
 {% endblock ewz_recaptcha_widget %}
-


### PR DESCRIPTION
I'm integrating this library into foscommentbundle, to show a captcha in the "new comment" form and another captcha in the "reply" form (which is dynamically added, an ajax call gets the form and then is appended to the DOM). Then I have two problems:
1. The library tries to reinit the captchas everytime the library is downloaded raising the error "ReCAPTCHA placeholder element must be empty" (this happens in every captcha widget)
2. Dynamically init the captcha (when the reply form is appended). I do this by using the parameter "render=explicit" when loading the library and call "grecaptcha.render" when needed.

To make this possible I added two possible parameters to the form widget.
* renderExplicit: When "true" the support for the stuff commented above is enabled. If false, it just use the actual code
* renderId: To make possible to render multiple captchas, every captcha needs an unique id which is provided with that parameter.

With these changes the recaptcha library is loaded once and the reused when other captchas are added.

An example of use is:

`
$builder->add('recaptcha', EWZRecaptchaType::class, array(
            'attr' => array(
                'options' => array(
                    'theme' => 'light',
                    'type'  => 'image',
                    'size'  => 'normal',
                    'defer' => true,
                    'async' => true,
                    'renderExplicit' => true,
                    'renderId' => uniqid()
                )
            )
        ));
`

In my case I use uniqid() because I don't care about the identifier, I just want to ensure the uniqueness.