### PR TITLE
Fixed exception, when invalid code has been sent.

### DIFF
--- a/Validator/Constraints/IsTrueValidator.php
+++ b/Validator/Constraints/IsTrueValidator.php
@@ -84,13 +84,14 @@ class IsTrueValidator extends ConstraintValidator
         // Verify user response with Google
         $response = $this->checkAnswer($this->privateKey, $remoteip, $answer);
 
-        // Perform server side hostname check
-        if ($this->verifyHost && $response['hostname'] !== $masterRequest->getHost()) {
-            $this->context->addViolation($constraint->invalidHostMessage);
-        }
-        elseif ($response['success'] !== true) {
+        if ($response['success'] !== true) {
             $this->context->addViolation($constraint->message);
         }
+        // Perform server side hostname check
+        elseif ($this->verifyHost && $response['hostname'] !== $masterRequest->getHost()) {
+            $this->context->addViolation($constraint->invalidHostMessage);
+        }
+
     }
 
     /**


### PR DESCRIPTION
`$response` may not to have `hostname` field if `$response['success']` is `false`, so it has to be tested first