### PR TITLE
Issue #147: Support for Google invisible reCAPTCHA

### DIFF
--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -6,9 +6,28 @@
                 {%- if attr.options.defer is defined and attr.options.defer %} defer{% endif -%}
                 {%- if attr.options.async is defined and attr.options.async %} async{% endif -%}
             ></script>
+
+            <script type="text/javascript">
+
+                var onReCaptchaSuccess = function (response) {
+                    var errorDivs = document.getElementsByClassName('recaptcha-error');
+                    if (errorDivs.length) {
+                        errorDivs[0].className = "";
+                    }
+                    var errorMsgs = document.getElementsByClassName('recaptcha-error-message');
+                    if (errorMsgs.length) {
+                        errorMsgs[0].parentNode.removeChild(errorMsgs[0]);
+                    }
+
+                    document.getElementsByClassName('reCaptchaForm')[0].submit();
+                };
+
+            </script>
+
             <div class="g-recaptcha" data-theme="{{ attr.options.theme }}" data-size="{{ attr.options.size }}" data-type="{{ attr.options.type }}" data-sitekey="{{ form.vars.public_key }}"
                  {%- if attr.options.callback is defined %} data-callback="{{ attr.options.callback }}"{% endif -%}
                  {%- if attr.options.expiredCallback is defined %} data-expired-callback="{{ attr.options.expiredCallback }}"{% endif -%}
+                 {%- if attr.options.bind is defined %} data-bind="{{ attr.options.bind }}"{% endif -%}
             ></div>
             <noscript>
                 <div style="width: 302px; height: 352px;">


### PR DESCRIPTION
## Description
Adding support for [Google's Invisible reCaptcha](https://www.google.com/recaptcha/intro/comingsoon/invisible.html) to the EWZ ReCaptcha Bundle

## Migrations
N/a

## Related Issue
[https://github.com/excelwebzone/EWZRecaptchaBundle/issues/147](https://github.com/excelwebzone/EWZRecaptchaBundle/issues/147)

## Steps to Test or Reproduce

The `EwzRecaptchaType` field in your form will need changed to include the following options.

The `bind` option should be the `id` of the submit button in your form.

The `size` should be set to 'invisible'.
 
    ->add('recaptcha', EWZRecaptchaType::class, [                
        'mapped' => false,
        'constraints' => [
            new Recaptcha\IsTrue(),
        ],
        'attr' => [
            'options' => [
                'theme' => 'light',
                'type' => 'image',
                'size' => 'invisible',
                'defer' => true,
                'async' => true,
                'callback' => 'onReCaptchaSuccess', 
                'bind' => 'appbundle_crmpicco_save',
            ]
        ]
    ])

When creating your form you will need to provide it with a class of 'reCaptchaForm', for example:

    $form = $this->createForm(AppBundle\Form\CRMPicco\PersonalType::class, $person, [
        'attr' => ['class' => 'reCaptchaForm'],
    ]);

## Author
Craig R Morton 
Analyst Developer - Moodle HQ
<craig@moodle.com>