### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
 
 before_script:
   - composer self-update


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.