### PR TITLE
Fix HTTP proxy configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ You can add HTTP Proxy configuration:
 
 ewz_recaptcha:
     // ...
-    host: proxy.mycompany.com
-    port: 3128
-    auth: proxy_username:proxy_password
+    http_proxy:
+        host: proxy.mycompany.com
+        port: 3128
+        auth: proxy_username:proxy_password
 ```
 
 In case you have turned off the domain name checking on reCAPTCHA's end, you'll need to check the origin of the response by enabling the ``verify_host`` option:


### PR DESCRIPTION
Fixed configuration example for HTTP_PROXY in README.md.
The properties host, port, auth should be children of
http_proxy node, not direct children of ewz_recaptcha node.