### PR TITLE
Check for the twig.form.resources parameter existence

### DIFF
--- a/src/DependencyInjection/EWZRecaptchaExtension.php
+++ b/src/DependencyInjection/EWZRecaptchaExtension.php
@@ -50,9 +50,17 @@ class EWZRecaptchaExtension extends Extension
             $formRessource = 'EWZRecaptchaBundle:Form:ewz_recaptcha_widget.html.twig';
 
             $container->setParameter('twig.form.resources', array_merge(
-                $container->getParameter('twig.form.resources'),
+                $this->getTwigFormResources($container),
                 array($formRessource)
             ));
         }
+    }
+
+    private function getTwigFormResources(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('twig.form.resources'))
+            return [];
+
+        return $container->getParameter('twig.form.resources');
     }
 }


### PR DESCRIPTION
Sometimes, twig.form.resources parameter does not exist, but this case was not handled.
Should fix https://github.com/excelwebzone/EWZRecaptchaBundle/issues/188