### PR TITLE
 Add an option `api_host` to custom the reCAPTCHA API server hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ ewz_recaptcha:
     ajax: true
 ```
 
+`www.google.com` is blocked in Mainland China, you can override the default server like this:
+
+``` yaml
+# app/config/config.yml
+
+ewz_recaptcha:
+    // ...
+    api_host: recaptcha.net
+```
+
 You can add HTTP Proxy configuration:
 
 ``` yaml

--- a/src/Bridge/Form/Extension/RecaptchaExtension.php
+++ b/src/Bridge/Form/Extension/RecaptchaExtension.php
@@ -38,7 +38,8 @@ class RecaptchaExtension extends AbstractExtension
                 $this->app['ewz_recaptcha.public_key'],
                 $this->app['ewz_recaptcha.enabled'],
                 $this->app['ewz_recaptcha.ajax'],
-                $this->app['ewz_recaptcha.locale_key']
+                $this->app['ewz_recaptcha.locale_key'],
+                $this->app['ewz_recaptcha.api_host']
             ),
         );
     }

--- a/src/Bridge/RecaptchaServiceProvider.php
+++ b/src/Bridge/RecaptchaServiceProvider.php
@@ -24,6 +24,7 @@ class RecaptchaServiceProvider implements ServiceProviderInterface
         $app['ewz_recaptcha.enabled'] = true;
         $app['ewz_recaptcha.verify_host'] = false;
         $app['ewz_recaptcha.ajax'] = false;
+        $app['ewz_recaptcha.api_host'] = 'www.google.com';
         $app['ewz_recaptcha.http_proxy'] = array(
             'host' => null,
             'port' => null,

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -27,6 +27,7 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('verify_host')->defaultFalse()->end()
                 ->booleanNode('ajax')->defaultFalse()->end()
                 ->scalarNode('locale_key')->defaultValue('%kernel.default_locale%')->end()
+                ->scalarNode('api_host')->defaultValue('www.google.com')->end()
                 ->booleanNode('locale_from_request')->defaultFalse()->end()
 				->arrayNode('trusted_roles')->prototype('scalar')->treatNullLike(array())->end()
             ->end()

--- a/src/Form/Type/EWZRecaptchaType.php
+++ b/src/Form/Type/EWZRecaptchaType.php
@@ -19,14 +19,14 @@ class EWZRecaptchaType extends AbstractType
      * 
      * @var string
      */
-    protected $RECAPTCHA_API_SERVER;
+    protected $recaptchaApiServer;
     
     /**
      * The reCAPTCHA JS server URL.
      * 
      * @var string
      */
-    protected $RECAPTCHA_API_JS_SERVER;
+    protected $recaptchaApiJsServer;
 
     /**
      * The public key.
@@ -67,15 +67,15 @@ class EWZRecaptchaType extends AbstractType
      * @param bool           $ajax           Ajax status
      * @param LocaleResolver $localeResolver
      */
-    public function __construct($publicKey, $enabled, $ajax, LocaleResolver $localeResolver, $apiHost='www.google.com')
+    public function __construct($publicKey, $enabled, $ajax, LocaleResolver $localeResolver, $apiHost = 'www.google.com')
     {
         $this->publicKey = $publicKey;
         $this->enabled = $enabled;
         $this->ajax = $ajax;
         $this->apiHost = $apiHost;
         $this->localeResolver = $localeResolver;
-        $this->RECAPTCHA_API_JS_SERVER = '//'.$apiHost.'/recaptcha/api/js/recaptcha_ajax.js';
-        $this->RECAPTCHA_API_SERVER = 'https://'.$apiHost.'/recaptcha/api.js';
+        $this->recaptchaApiJsServer = sprintf('//%s/recaptcha/api/js/recaptcha_ajax.js', $apiHost);
+        $this->recaptchaApiServer = sprintf('https://%s/recaptcha/api.js', $apiHost);
     }
 
     /**
@@ -99,12 +99,12 @@ class EWZRecaptchaType extends AbstractType
 
         if (!$this->ajax) {
             $view->vars = array_replace($view->vars, array(
-                'url_challenge' => sprintf('%s?hl=%s', $this->RECAPTCHA_API_SERVER, $options['language']),
+                'url_challenge' => sprintf('%s?hl=%s', $this->recaptchaApiServer, $options['language']),
                 'public_key' => $this->publicKey,
             ));
         } else {
             $view->vars = array_replace($view->vars, array(
-                'url_api' => $this->RECAPTCHA_API_JS_SERVER,
+                'url_api' => $this->recaptchaApiJsServer,
                 'public_key' => $this->publicKey,
             ));
         }

--- a/src/Form/Type/EWZRecaptchaType.php
+++ b/src/Form/Type/EWZRecaptchaType.php
@@ -15,10 +15,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class EWZRecaptchaType extends AbstractType
 {
     /**
-     * The reCAPTCHA server URL's.
+     * The reCAPTCHA server URL.
+     * 
+     * @var string
      */
-    const RECAPTCHA_API_SERVER = 'https://www.google.com/recaptcha/api.js';
-    const RECAPTCHA_API_JS_SERVER = '//www.google.com/recaptcha/api/js/recaptcha_ajax.js';
+    protected $RECAPTCHA_API_SERVER;
+    
+    /**
+     * The reCAPTCHA JS server URL.
+     * 
+     * @var string
+     */
+    protected $RECAPTCHA_API_JS_SERVER;
 
     /**
      * The public key.
@@ -26,6 +34,13 @@ class EWZRecaptchaType extends AbstractType
      * @var string
      */
     protected $publicKey;
+
+    /**
+     * The API server host name.
+     *
+     * @var string
+     */
+    protected $apiHost;
 
     /**
      * Enable recaptcha?
@@ -52,12 +67,15 @@ class EWZRecaptchaType extends AbstractType
      * @param bool           $ajax           Ajax status
      * @param LocaleResolver $localeResolver
      */
-    public function __construct($publicKey, $enabled, $ajax, LocaleResolver $localeResolver)
+    public function __construct($publicKey, $enabled, $ajax, LocaleResolver $localeResolver, $apiHost='www.google.com')
     {
         $this->publicKey = $publicKey;
         $this->enabled = $enabled;
         $this->ajax = $ajax;
+        $this->apiHost = $apiHost;
         $this->localeResolver = $localeResolver;
+        $this->RECAPTCHA_API_JS_SERVER = '//'.$apiHost.'/recaptcha/api/js/recaptcha_ajax.js';
+        $this->RECAPTCHA_API_SERVER = 'https://'.$apiHost.'/recaptcha/api.js';
     }
 
     /**
@@ -68,6 +86,7 @@ class EWZRecaptchaType extends AbstractType
         $view->vars = array_replace($view->vars, array(
             'ewz_recaptcha_enabled' => $this->enabled,
             'ewz_recaptcha_ajax' => $this->ajax,
+            'ewz_recaptcha_apihost' => $this->apiHost
         ));
 
         if (!$this->enabled) {
@@ -80,12 +99,12 @@ class EWZRecaptchaType extends AbstractType
 
         if (!$this->ajax) {
             $view->vars = array_replace($view->vars, array(
-                'url_challenge' => sprintf('%s?hl=%s', self::RECAPTCHA_API_SERVER, $options['language']),
+                'url_challenge' => sprintf('%s?hl=%s', $this->RECAPTCHA_API_SERVER, $options['language']),
                 'public_key' => $this->publicKey,
             ));
         } else {
             $view->vars = array_replace($view->vars, array(
-                'url_api' => self::RECAPTCHA_API_JS_SERVER,
+                'url_api' => $this->RECAPTCHA_API_JS_SERVER,
                 'public_key' => $this->publicKey,
             ));
         }
@@ -154,5 +173,15 @@ class EWZRecaptchaType extends AbstractType
     public function getPublicKey()
     {
         return $this->publicKey;
+    }
+
+    /**
+     * Gets the API host name.
+     *
+     * @return string The hostname for API
+     */
+    public function getApiHost()
+    {
+        return $this->apiHost;
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,6 +15,7 @@ services:
             - '%ewz_recaptcha.enabled%'
             - '%ewz_recaptcha.ajax%'
             - '@ewz_recaptcha.locale.resolver'
+            - '%ewz_recaptcha.api_host%'
         tags:
             - { name: form.type }
 
@@ -29,5 +30,6 @@ services:
             - '%ewz_recaptcha.verify_host%'
             - '@?security.authorization_checker'
             - '%ewz_recaptcha.trusted_roles%'
+            - '%ewz_recaptcha.api_host%'
         tags:
             - { name: validator.constraint_validator, alias: 'ewz_recaptcha.true' }

--- a/src/Resources/translations/validators.zh_CN.xlf
+++ b/src/Resources/translations/validators.zh_CN.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>This value is not a valid captcha.</source>
+                <target>没有有效完成验证码。</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>The captcha was not resolved on the right domain.</source>
+                <target>验证码在不正确的域名上完成。</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.php
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.php
@@ -42,7 +42,7 @@
             <div style="width: 302px; height: 352px;">
                 <div style="width: 302px; height: 352px; position: relative;">
                     <div style="width: 302px; height: 352px; position: absolute;">
-                        <iframe src="https://www.google.com/recaptcha/api/fallback?k=<?php echo $public_key ?>"
+                        <iframe src="https://<?php echo $ewz_recaptcha_apihost ?>/recaptcha/api/fallback?k=<?php echo $public_key ?>"
                                 frameborder="0" scrolling="no"
                                 style="width: 302px; height:352px; border-style: none;"
                         >

--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -45,7 +45,7 @@
                 <div style="width: 302px; height: 352px;">
                     <div style="width: 302px; height: 352px; position: relative;">
                         <div style="width: 302px; height: 352px; position: absolute;">
-                            <iframe src="https://www.google.com/recaptcha/api/fallback?k={{ form.vars.public_key }}"
+                            <iframe src="https://{{ form.vars.ewz_recaptcha_apihost }}/recaptcha/api/fallback?k={{ form.vars.public_key }}"
                                     frameborder="0" scrolling="no"
                                     style="width: 302px; height:352px; border-style: none;"
                             >

--- a/src/Validator/Constraints/IsTrueValidator.php
+++ b/src/Validator/Constraints/IsTrueValidator.php
@@ -64,7 +64,7 @@ class IsTrueValidator extends ConstraintValidator
      * 
      * @var string
      */
-    protected $RECAPTCHA_VERIFY_SERVER;
+    protected $recaptchaVerifyServer;
 
     /**
      * @param bool                               $enabled
@@ -83,7 +83,7 @@ class IsTrueValidator extends ConstraintValidator
         $verifyHost,
         AuthorizationCheckerInterface $authorizationChecker = null,
         array $trusted_roles = array(),
-        $apiHost='www.google.com')
+        $apiHost = 'www.google.com')
     {
         $this->enabled = $enabled;
         $this->privateKey = $privateKey;
@@ -92,7 +92,7 @@ class IsTrueValidator extends ConstraintValidator
         $this->verifyHost = $verifyHost;
         $this->authorizationChecker = $authorizationChecker;
         $this->trusted_roles = $trusted_roles;
-        $this->RECAPTCHA_VERIFY_SERVER = 'https://'.$apiHost;
+        $this->recaptchaVerifyServer = 'https://'.$apiHost;
     }
 
     /**
@@ -149,7 +149,7 @@ class IsTrueValidator extends ConstraintValidator
             return false;
         }
 
-        $response = $this->httpGet($this->RECAPTCHA_VERIFY_SERVER, '/recaptcha/api/siteverify', array(
+        $response = $this->httpGet($this->recaptchaVerifyServer, '/recaptcha/api/siteverify', array(
             'secret' => $privateKey,
             'remoteip' => $remoteip,
             'response' => $answer,

--- a/src/Validator/Constraints/IsTrueValidator.php
+++ b/src/Validator/Constraints/IsTrueValidator.php
@@ -20,7 +20,7 @@ class IsTrueValidator extends ConstraintValidator
     /**
      * Recaptcha Private Key.
      *
-     * @var bool
+     * @var string
      */
     protected $privateKey;
 
@@ -60,9 +60,11 @@ class IsTrueValidator extends ConstraintValidator
     protected $trusted_roles;
 
     /**
-     * The reCAPTCHA server URL's.
+     * The reCAPTCHA verify server URL.
+     * 
+     * @var string
      */
-    const RECAPTCHA_VERIFY_SERVER = 'https://www.google.com';
+    protected $RECAPTCHA_VERIFY_SERVER;
 
     /**
      * @param bool                               $enabled
@@ -80,7 +82,8 @@ class IsTrueValidator extends ConstraintValidator
         array $httpProxy,
         $verifyHost,
         AuthorizationCheckerInterface $authorizationChecker = null,
-        array $trusted_roles = array())
+        array $trusted_roles = array(),
+        $apiHost='www.google.com')
     {
         $this->enabled = $enabled;
         $this->privateKey = $privateKey;
@@ -89,6 +92,7 @@ class IsTrueValidator extends ConstraintValidator
         $this->verifyHost = $verifyHost;
         $this->authorizationChecker = $authorizationChecker;
         $this->trusted_roles = $trusted_roles;
+        $this->RECAPTCHA_VERIFY_SERVER = 'https://'.$apiHost;
     }
 
     /**
@@ -145,7 +149,7 @@ class IsTrueValidator extends ConstraintValidator
             return false;
         }
 
-        $response = $this->httpGet(self::RECAPTCHA_VERIFY_SERVER, '/recaptcha/api/siteverify', array(
+        $response = $this->httpGet($this->RECAPTCHA_VERIFY_SERVER, '/recaptcha/api/siteverify', array(
             'secret' => $privateKey,
             'remoteip' => $remoteip,
             'response' => $answer,

--- a/tests/Form/Type/EWZRecaptchaTypeTest.php
+++ b/tests/Form/Type/EWZRecaptchaTypeTest.php
@@ -19,7 +19,7 @@ class EWZRecaptchaTypeTest extends \PHPUnit_Framework_TestCase
     {
         $requestStack = $this->createMock(RequestStack::class);
         $localeResolver = new LocaleResolver('de', false, $requestStack);
-        $this->type = new EWZRecaptchaType('key', true, true, $localeResolver);
+        $this->type = new EWZRecaptchaType('key', true, true, $localeResolver, 'www.google.com');
     }
 
     /**


### PR DESCRIPTION
The host `www.google.com` introduced in Google document is blocked in Mainland China. For Chinese users, a solution is to use an official reverse proxy server `recaptcha.net`. So I add an option `api_host`(default value: `www.google.com`) to change the reCAPTCHA API server's hostname.