### PR TITLE
Use Twig namespaced syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ However, you can always implement your own custom form widget.
 **Twig**:
 
 ``` jinja
-{% form_theme form 'EWZRecaptchaBundle:Form:ewz_recaptcha_widget.html.twig' %}
+{% form_theme form '@EWZRecaptcha/Form/ewz_recaptcha_widget.html.twig' %}
 
 {{ form_widget(form.recaptcha, { 'attr': {
     'options' : {
@@ -345,7 +345,7 @@ If you want to use a custom theme, put your chunk of code before setting the the
    <div><a href="javascript:Recaptcha.showhelp()">Help</a></div>
  </div>
 
-{% form_theme form 'EWZRecaptchaBundle:Form:ewz_recaptcha_widget.html.twig' %}
+{% form_theme form '@EWZRecaptcha/Form/ewz_recaptcha_widget.html.twig' %}
 
 {{ form_widget(form.recaptcha, { 'attr': {
     'options' : {

--- a/src/DependencyInjection/EWZRecaptchaExtension.php
+++ b/src/DependencyInjection/EWZRecaptchaExtension.php
@@ -51,7 +51,7 @@ class EWZRecaptchaExtension extends Extension
         }
 
         if (in_array('twig', $templatingEngines)) {
-            $formResource = 'EWZRecaptchaBundle:Form:ewz_recaptcha_widget.html.twig';
+            $formResource = '@EWZRecaptcha/Form/ewz_recaptcha_widget.html.twig';
 
             $container->setParameter('twig.form.resources', array_merge(
                 $this->getTwigFormResources($container),


### PR DESCRIPTION
This should fix Symfony 4 compatibility forever, without the need of resetting the `templating.engines` and putting it manually in the `form_themes` (see #188). 