### PR TITLE
Restore support for php 5.3, 5.4, 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ cache:
 matrix:
   fast_finish: true
   include:
+    - php: 5.3
+      env: SYMFONY_VERSION=^2.8
+      dist: precise
+
+    - php: 5.4
+      env: SYMFONY_VERSION=^2.8
+
+    - php: 5.5
+      env: SYMFONY_VERSION=^2.8
+    - php: 5.5
+      env: SYMFONY_VERSION=^3
+
     - php: 5.6
       env: SYMFONY_VERSION=^2.8
     - php: 5.6

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6 || ^7.0",
+    "php": ">=5.3.2 || ^7.0",
     "google/recaptcha": "^1.1",
     "symfony/form": "^2.8 || ^3.0 || ^4.0",
     "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
@@ -23,7 +23,8 @@
     "symfony/validator": "^2.8 || ^3.0 || ^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5 || ^6 || ^7"
+    "phpunit/phpunit": "^5 || ^6 || ^7",
+    "mockery/mockery": "^1 | ^0.9"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "symfony/validator": "^2.8 || ^3.0 || ^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5 || ^6 || ^7",
+    "phpunit/phpunit": "^4 || ^5 || ^6 || ^7",
     "mockery/mockery": "^1 | ^0.9"
   },
   "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,8 @@
     </whitelist>
   </filter>
 
+  <logging>
+    <log type="coverage-text" target="php://stdout" />
+  </logging>
+
 </phpunit>

--- a/src/DependencyInjection/EWZRecaptchaExtension.php
+++ b/src/DependencyInjection/EWZRecaptchaExtension.php
@@ -63,7 +63,7 @@ class EWZRecaptchaExtension extends Extension
     private function getTwigFormResources(ContainerBuilder $container)
     {
         if (!$container->hasParameter('twig.form.resources'))
-            return [];
+            return array();
 
         return $container->getParameter('twig.form.resources');
     }

--- a/src/Form/Type/EWZRecaptchaType.php
+++ b/src/Form/Type/EWZRecaptchaType.php
@@ -3,7 +3,6 @@
 namespace EWZ\Bundle\RecaptchaBundle\Form\Type;
 
 use EWZ\Bundle\RecaptchaBundle\Locale\LocaleResolver;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\AbstractType;
@@ -16,14 +15,14 @@ class EWZRecaptchaType extends AbstractType
 {
     /**
      * The reCAPTCHA server URL.
-     * 
+     *
      * @var string
      */
     protected $recaptchaApiServer;
-    
+
     /**
      * The reCAPTCHA JS server URL.
-     * 
+     *
      * @var string
      */
     protected $recaptchaApiJsServer;
@@ -142,7 +141,7 @@ class EWZRecaptchaType extends AbstractType
      */
     public function getParent()
     {
-        return TextType::class;
+        return 'Symfony\Component\Form\Extension\Core\Type\TextType';
     }
 
     /**

--- a/tests/Form/Type/EWZRecaptchaTypeTest.php
+++ b/tests/Form/Type/EWZRecaptchaTypeTest.php
@@ -4,11 +4,10 @@ namespace EWZ\Tests\Bundle\RecaptchaBundle\Form\Type;
 
 use EWZ\Bundle\RecaptchaBundle\Form\Type\EWZRecaptchaType;
 use EWZ\Bundle\RecaptchaBundle\Locale\LocaleResolver;
+use Mockery;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EWZRecaptchaTypeTest extends TestCase
@@ -18,7 +17,7 @@ class EWZRecaptchaTypeTest extends TestCase
 
     protected function setUp()
     {
-        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack = Mockery::mock('Symfony\Component\HttpFoundation\RequestStack');
         $localeResolver = new LocaleResolver('de', false, $requestStack);
         $this->type = new EWZRecaptchaType('key', true, true, $localeResolver, 'www.google.com');
     }
@@ -31,7 +30,7 @@ class EWZRecaptchaTypeTest extends TestCase
         $view = new FormView();
 
         /** @var FormInterface $form */
-        $form = $this->createMock(FormInterface::class);
+        $form = Mockery::mock('Symfony\Component\Form\FormInterface');
 
         $this->assertArrayNotHasKey('ewz_recaptcha_enabled', $view->vars);
         $this->assertArrayNotHasKey('ewz_recaptcha_ajax', $view->vars);
@@ -47,7 +46,7 @@ class EWZRecaptchaTypeTest extends TestCase
      */
     public function getParent()
     {
-        $this->assertSame(TextType::class, $this->type->getParent());
+        $this->assertSame('Symfony\Component\Form\Extension\Core\Type\TextType', $this->type->getParent());
     }
 
     /**

--- a/tests/Locale/LocaleResolverTest.php
+++ b/tests/Locale/LocaleResolverTest.php
@@ -3,9 +3,8 @@
 namespace EWZ\Tests\Bundle\RecaptchaBundle\Locale;
 
 use EWZ\Bundle\RecaptchaBundle\Locale\LocaleResolver;
+use Mockery;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 
 class LocaleResolverTest extends TestCase
 {
@@ -14,17 +13,14 @@ class LocaleResolverTest extends TestCase
      */
     public function resolveWithLocaleFromRequest()
     {
-        $request = $this->createMock(Request::class);
-        $request->expects($this->once())->method('getLocale');
+        $request = Mockery::mock('Symfony\Component\HttpFoundation\Request');
+        $request->shouldReceive('getLocale')->once()->andReturn('foo');
 
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack
-            ->expects($this->once())
-            ->method('getCurrentRequest')
-            ->willReturn($request);
+        $requestStack = Mockery::mock('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack->shouldReceive('getCurrentRequest')->once()->andReturn($request);
 
         $resolver = new LocaleResolver('foo', true, $requestStack);
-        $resolver->resolve();
+        $this->assertSame('foo', $resolver->resolve());
     }
 
     /**
@@ -32,12 +28,10 @@ class LocaleResolverTest extends TestCase
      */
     public function resolveWithDefaultLocale()
     {
-        $requestStack = $this->createMock(RequestStack::class);
-        $requestStack
-            ->expects($this->never())
-            ->method('getCurrentRequest');
+        $requestStack = Mockery::mock('Symfony\Component\HttpFoundation\RequestStack');
+        $requestStack->shouldReceive('getCurrentRequest')->never();
 
         $resolver = new LocaleResolver('foo', false, $requestStack);
-        $resolver->resolve();
+        $this->assertSame('foo', $resolver->resolve());
     }
 }


### PR DESCRIPTION
As older versions of Symfony use those versions it would make sense that this project support those too.

What I did was just that and add testing environments on Travis.

No features were lost, as they were not really used.

- `[]` had to be changed to `array()`
- `::class` constant started from php 5.5, so use the namespace\class manually
- PhpUnit introduced `->createMock()` in v5. To replace it, Mockery can be used. (v4 is needed for tests below php 5.6)