### PR TITLE
Add timeout for the reCAPTCHA verification

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('locale_key')->defaultValue('%kernel.default_locale%')->end()
                 ->scalarNode('api_host')->defaultValue('www.google.com')->end()
                 ->booleanNode('locale_from_request')->defaultFalse()->end()
+                ->integerNode('timeout')->min(0)->defaultNull()->end()
 				->arrayNode('trusted_roles')->prototype('scalar')->treatNullLike(array())->end()
             ->end()
         ;

--- a/src/Extension/ReCaptcha/RequestMethod/Post.php
+++ b/src/Extension/ReCaptcha/RequestMethod/Post.php
@@ -31,7 +31,7 @@ class Post implements RequestMethod
      */
     public function __construct($recaptchaVerifyServer, $timeout)
     {
-        $this->recaptchaVerifyUrl ='https://www.google.com:81/recaptcha/api/siteverify';
+        $this->recaptchaVerifyUrl = ($recaptchaVerifyServer ?: 'https://www.google.com').'/recaptcha/api/siteverify';
         $this->timeout = $timeout;
     }
 

--- a/src/Extension/ReCaptcha/RequestMethod/Post.php
+++ b/src/Extension/ReCaptcha/RequestMethod/Post.php
@@ -18,13 +18,21 @@ class Post implements RequestMethod
     private $recaptchaVerifyUrl;
 
     /**
+     * The timeout for the reCAPTCHA verification.
+     *
+     * @var int|null
+     */
+    private $timeout;
+
+    /**
      * Constructor
      *
      * @param string $recaptchaVerifyServer
      */
-    public function __construct($recaptchaVerifyServer)
+    public function __construct($recaptchaVerifyServer, $timeout)
     {
-        $this->recaptchaVerifyUrl = ($recaptchaVerifyServer ?: 'https://www.google.com').'/recaptcha/api/siteverify';
+        $this->recaptchaVerifyUrl ='https://www.google.com:81/recaptcha/api/siteverify';
+        $this->timeout = $timeout;
     }
 
     /**
@@ -51,6 +59,9 @@ class Post implements RequestMethod
                 $peer_key => 'www.google.com',
             ),
         );
+        if (null !== $this->timeout) {
+            $options['http']['timeout'] = $this->timeout;
+        }
         $context = stream_context_create($options);
         return file_get_contents($this->recaptchaVerifyUrl, false, $context);
     }

--- a/src/Extension/ReCaptcha/RequestMethod/ProxyPost.php
+++ b/src/Extension/ReCaptcha/RequestMethod/ProxyPost.php
@@ -25,15 +25,23 @@ class ProxyPost implements RequestMethod
     private $recaptchaVerifyUrl;
 
     /**
+     * The timeout for the reCAPTCHA verification.
+     *
+     * @var int|null
+     */
+    private $timeout;
+
+    /**
      * Constructor
      *
      * @param array $httpProxy proxy data to connect to
      * @param string $recaptchaVerifyServer
      */
-    public function __construct(array $httpProxy, $recaptchaVerifyServer)
+    public function __construct(array $httpProxy, $recaptchaVerifyServer, $timeout)
     {
         $this->httpProxy = $httpProxy;
         $this->recaptchaVerifyUrl = ($recaptchaVerifyServer ?: 'https://www.google.com').'/recaptcha/api/siteverify';
+        $this->timeout = $timeout;
     }
 
     /**
@@ -64,6 +72,9 @@ class ProxyPost implements RequestMethod
                 'request_fulluri' => true,
             ),
         );
+        if (null !== $this->timeout) {
+            $options['http']['timeout'] = $this->timeout;
+        }
         $context = stream_context_create($options);
         return file_get_contents($this->recaptchaVerifyUrl, false, $context);
     }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -31,5 +31,6 @@ services:
             - '@?security.authorization_checker'
             - '%ewz_recaptcha.trusted_roles%'
             - '%ewz_recaptcha.api_host%'
+            - '%ewz_recaptcha.timeout%'
         tags:
             - { name: validator.constraint_validator, alias: 'ewz_recaptcha.true' }

--- a/src/Validator/Constraints/IsTrueValidator.php
+++ b/src/Validator/Constraints/IsTrueValidator.php
@@ -70,6 +70,13 @@ class IsTrueValidator extends ConstraintValidator
     protected $recaptchaVerifyServer;
 
     /**
+     * The timeout for the reCAPTCHA verification.
+     *
+     * @var int|null
+     */
+    private $timeout;
+
+    /**
      * @param bool                               $enabled
      * @param string                             $privateKey
      * @param RequestStack                       $requestStack
@@ -78,6 +85,7 @@ class IsTrueValidator extends ConstraintValidator
      * @param AuthorizationCheckerInterface|null $authorizationChecker
      * @param array                              $trustedRoles
      * @param string                             $apiHost
+     * @param int|null                           $timeout
      */
     public function __construct(
         $enabled,
@@ -87,7 +95,8 @@ class IsTrueValidator extends ConstraintValidator
         $verifyHost,
         AuthorizationCheckerInterface $authorizationChecker = null,
         array $trustedRoles = array(),
-        $apiHost = 'www.google.com')
+        $apiHost = 'www.google.com',
+        $timeout = null)
     {
         $this->enabled = $enabled;
         $this->privateKey = $privateKey;
@@ -97,6 +106,7 @@ class IsTrueValidator extends ConstraintValidator
         $this->authorizationChecker = $authorizationChecker;
         $this->trustedRoles = $trustedRoles;
         $this->recaptchaVerifyServer = 'https://'.$apiHost;
+        $this->timeout = $timeout;
     }
 
     /**
@@ -123,9 +133,9 @@ class IsTrueValidator extends ConstraintValidator
 
         // Verify user response with Google
         if (null !== $this->httpProxy['host'] && null !== $this->httpProxy['port']) {
-            $requestMethod = new ProxyPost($this->httpProxy, $this->recaptchaVerifyServer);
+            $requestMethod = new ProxyPost($this->httpProxy, $this->recaptchaVerifyServer, $this->timeout);
         } else {
-            $requestMethod = new Post($this->recaptchaVerifyServer);
+            $requestMethod = new Post($this->recaptchaVerifyServer, $this->timeout);
         }
         $recaptcha = new ReCaptcha($this->privateKey, $requestMethod);
         $response = $recaptcha->verify($answer, $remoteip);


### PR DESCRIPTION
This PR allows the user set a timeout for the reCAPTCHA verification.
This is a way to fix the #143 issue. 
It adds a new parameter timeout which can be a number > 0 or null by default.
The timeout param is added to the file_get_content only context if the timeout is not null
When the timeout is reached, a ContextErrorException is thrown
```
ContextErrorException {#6464 ▼
  -context: array:4 [▶]
  #message: "Warning: file_get_contents(https://www.google.com:81/recaptcha/api/siteverify): failed to open stream: Connection timed out"
  #code: 0
  #file: "/home/homes/m.giraudtelme/apps/mxm/vendor/excelwebzone/recaptcha-bundle/src/Extension/ReCaptcha/RequestMethod/Post.php"
  #line: 66
  #severity: E_WARNING
  trace: {▶}
}
```

The user can easily catch this exception.
