### PR TITLE
replaced deprecated spaceless tag with filter in Twig template

### DIFF
--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -1,5 +1,5 @@
 {% block ewz_recaptcha_widget %}
-{% spaceless %}
+{% filter spaceless %}
     {% if form.vars.ewz_recaptcha_enabled %}
         {% if not form.vars.ewz_recaptcha_ajax %}
             {% if attr.options.size == 'invisible' and attr.options.callback is not defined %}
@@ -79,6 +79,6 @@
             </script>
         {% endif %}
     {% endif %}
-{% endspaceless %}
+{% endfilter %}
 {% endblock ewz_recaptcha_widget %}
 


### PR DESCRIPTION
The spaceless tag is deprecated since Twig 2.7
The alternative is to use the filter function.

https://twig.symfony.com/doc/2.x/tags/spaceless.html
https://twig.symfony.com/doc/2.x/filters/spaceless.html