### PR TITLE
Use required phpunit instead global in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ before_script:
   - composer install
 
 script:
-  - phpunit
+  - vendor/bin/phpunit


### PR DESCRIPTION
Because in travis CI the default phpunit is version 8 for php 7.2 we need to use phpunit that's required in composer.json