### PR TITLE
Specify Twig version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "symfony/form": "^2.8 || ^3.0 || ^4.0",
     "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0",
     "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0",
-    "symfony/validator": "^2.8 || ^3.0 || ^4.0"
+    "symfony/validator": "^2.8 || ^3.0 || ^4.0",
+    "twig/twig": "^1.40 || ^2.9"
   },
   "require-dev": {
     "phpunit/phpunit": "^5 || ^6 || ^7"


### PR DESCRIPTION
After https://github.com/excelwebzone/EWZRecaptchaBundle/commit/f526d3036616529a7c1be81e5ddea5af5b4fd331 the form layout is not compatible with older versions of Twig, the bundle should correctly advertise this.