### PR TITLE
Enable caching recaptcha verify response in array cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
     "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0",
     "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+    "symfony/yaml": "^2.8 || ^3.0 || ^4.0 || ^5.0",
     "twig/twig": "^1.40 || ^2.9 || ^3.0"
   },
   "require-dev": {

--- a/src/DependencyInjection/EWZRecaptchaExtension.php
+++ b/src/DependencyInjection/EWZRecaptchaExtension.php
@@ -4,6 +4,7 @@ namespace EWZ\Bundle\RecaptchaBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
@@ -28,6 +29,11 @@ class EWZRecaptchaExtension extends Extension
         }
 
         $this->registerWidget($container);
+
+        if (null !== $config['http_proxy']['host'] && null !== $config['http_proxy']['port']) {
+            $recaptchaService = $container->findDefinition('ewz_recaptcha.recaptcha');
+            $recaptchaService->replaceArgument(1, new Reference('ewz_recaptcha.extension.recaptcha.request_method.proxy_post'));
+        }
     }
 
     /**

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -24,13 +24,32 @@ services:
         public: true
         arguments:
             - '%ewz_recaptcha.enabled%'
-            - '%ewz_recaptcha.private_key%'
+            - '@ewz_recaptcha.recaptcha'
             - '@request_stack'
-            - '%ewz_recaptcha.http_proxy%'
             - '%ewz_recaptcha.verify_host%'
             - '@?security.authorization_checker'
             - '%ewz_recaptcha.trusted_roles%'
-            - '%ewz_recaptcha.api_host%'
-            - '%ewz_recaptcha.timeout%'
         tags:
             - { name: validator.constraint_validator, alias: 'ewz_recaptcha.true' }
+
+    ewz_recaptcha.recaptcha:
+      class: ReCaptcha\ReCaptcha
+      public: false
+      arguments:
+        - '%ewz_recaptcha.private_key%'
+        - '@ewz_recaptcha.extension.recaptcha.request_method.post'
+
+    ewz_recaptcha.extension.recaptcha.request_method.post:
+      class: EWZ\Bundle\RecaptchaBundle\Extension\ReCaptcha\RequestMethod\Post
+      public: false
+      arguments:
+        - 'https://%ewz_recaptcha.api_host%'
+        - '%ewz_recaptcha.timeout%'
+
+    ewz_recaptcha.extension.recaptcha.request_method.proxy_post:
+      class: EWZ\Bundle\RecaptchaBundle\Extension\ReCaptcha\RequestMethod\ProxyPost
+      public: false
+      arguments:
+        - '%ewz_recaptcha.http_proxy%'
+        - 'https://%ewz_recaptcha.api_host%'
+        - '%ewz_recaptcha.timeout%'

--- a/tests/DependencyInjection/EWZRecaptchaExtensionTest.php
+++ b/tests/DependencyInjection/EWZRecaptchaExtensionTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace EWZ\Tests\Bundle\RecaptchaBundle\DependencyInjection;
+
+use EWZ\Bundle\RecaptchaBundle\DependencyInjection\EWZRecaptchaExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Yaml\Parser;
+
+/**
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class EWZRecaptchaExtensionTest extends TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $configuration;
+
+    protected function tearDown()
+    {
+        $this->configuration = null;
+    }
+
+    public function testSimpleConfiguration()
+    {
+        $this->configuration = new ContainerBuilder();
+        $loader = new EWZRecaptchaExtension();
+        $config = $this->getSimpleConfig();
+        $loader->load([$config], $this->configuration);
+
+        $this->assertParameter(true, 'ewz_recaptcha.enabled');
+        $this->assertParameter('foo_public_key', 'ewz_recaptcha.public_key');
+        $this->assertParameter('bar_private_key', 'ewz_recaptcha.private_key');
+        $this->assertParameter(false, 'ewz_recaptcha.verify_host');
+        $this->assertParameter(false, 'ewz_recaptcha.ajax');
+        $this->assertParameter('%kernel.default_locale%', 'ewz_recaptcha.locale_key');
+        $this->assertParameter('www.google.com', 'ewz_recaptcha.api_host');
+        $this->assertParameter(false, 'ewz_recaptcha.locale_from_request');
+        $this->assertParameter(null, 'ewz_recaptcha.timeout');
+        $this->assertParameter([], 'ewz_recaptcha.trusted_roles');
+        $this->assertParameter(
+            ['host' => null, 'port' => null, 'auth' => null],
+            'ewz_recaptcha.http_proxy'
+        );
+
+        $this->assertHasDefinition('ewz_recaptcha.locale.resolver');
+        $this->assertHasDefinition('ewz_recaptcha.form.type');
+        $this->assertHasDefinition('ewz_recaptcha.validator.true');
+        $this->assertHasDefinition('ewz_recaptcha.recaptcha');
+        $this->assertHasDefinition('ewz_recaptcha.extension.recaptcha.request_method.post');
+        $this->assertHasDefinition('ewz_recaptcha.extension.recaptcha.request_method.proxy_post');
+
+        $this->assertDefinitionHasReferenceArgument(
+            'ewz_recaptcha.recaptcha',
+            1,
+            'ewz_recaptcha.extension.recaptcha.request_method.post'
+        );
+    }
+
+    public function testFullConfiguration()
+    {
+        $this->configuration = new ContainerBuilder();
+        $loader = new EWZRecaptchaExtension();
+        $config = $this->getFullConfig();
+        $loader->load([$config], $this->configuration);
+
+        $this->assertParameter(true, 'ewz_recaptcha.enabled');
+        $this->assertParameter('foo_public_key', 'ewz_recaptcha.public_key');
+        $this->assertParameter('bar_private_key', 'ewz_recaptcha.private_key');
+        $this->assertParameter(true, 'ewz_recaptcha.verify_host');
+        $this->assertParameter(true, 'ewz_recaptcha.ajax');
+        $this->assertParameter('sk', 'ewz_recaptcha.locale_key');
+        $this->assertParameter('www.example.com', 'ewz_recaptcha.api_host');
+        $this->assertParameter(true, 'ewz_recaptcha.locale_from_request');
+        $this->assertParameter(10, 'ewz_recaptcha.timeout');
+        $this->assertParameter(['role_foo'], 'ewz_recaptcha.trusted_roles');
+        $this->assertParameter(
+            ['host' => 'http://foo.example.com', 'port' => 80, 'auth' => 'bar:baz'],
+            'ewz_recaptcha.http_proxy'
+        );
+
+        $this->assertHasDefinition('ewz_recaptcha.locale.resolver');
+        $this->assertHasDefinition('ewz_recaptcha.form.type');
+        $this->assertHasDefinition('ewz_recaptcha.validator.true');
+        $this->assertHasDefinition('ewz_recaptcha.recaptcha');
+        $this->assertHasDefinition('ewz_recaptcha.extension.recaptcha.request_method.post');
+        $this->assertHasDefinition('ewz_recaptcha.extension.recaptcha.request_method.proxy_post');
+
+        $this->assertDefinitionHasReferenceArgument(
+            'ewz_recaptcha.recaptcha',
+            1,
+            'ewz_recaptcha.extension.recaptcha.request_method.proxy_post'
+        );
+    }
+
+    private function getSimpleConfig()
+    {
+        $yaml = <<<EOF
+public_key: 'foo_public_key'
+private_key: 'bar_private_key'
+EOF;
+        $parser = new Parser();
+
+        return $parser->parse($yaml);
+    }
+
+    private function getFullConfig()
+    {
+        $yaml = <<<EOF
+public_key: 'foo_public_key'
+private_key: 'bar_private_key'
+enabled: true
+verify_host: true
+ajax: true
+locale_key: 'sk'
+api_host: 'www.example.com'
+locale_from_request: true
+timeout: 10
+trusted_roles:
+    - 'role_foo'
+http_proxy:
+    host: 'http://foo.example.com'
+    port: 80
+    auth: 'bar:baz'
+EOF;
+        $parser = new Parser();
+
+        return $parser->parse($yaml);
+    }
+
+    private function assertParameter($value, $key)
+    {
+        $this->assertSame($value, $this->configuration->getParameter($key), sprintf('%s parameter is correct', $key));
+    }
+
+    private function assertHasDefinition($id)
+    {
+        $this->assertTrue(($this->configuration->hasDefinition($id) ?: $this->configuration->hasAlias($id)));
+    }
+
+    private function assertDefinitionHasReferenceArgument($id, $index, $expectedArgumentValue)
+    {
+        $definition = $this->configuration->getDefinition($id);
+        $argumentValue = $definition->getArgument($index);
+
+        $this->assertInstanceOf(Reference::class, $argumentValue);
+        $this->assertSame($expectedArgumentValue, (string)$argumentValue);
+    }
+}


### PR DESCRIPTION
There are few situations when you have to call the `IsTrueValidator` twice in one request. This is not possible now, because Googlke recaptcha accepts the value only once. So first validation will pass, second will fail. 

This PR enables the caching of the recaptcha response, so the `IsTrueValidator` (and their dependencies) will use the response from the first verify call.

The `IsTrueValidator` is also simplified with the dependency injection. Recaptcha serivce is not creating during the validation process, but is injected to the constraint as dependency.