### PR TITLE
Fix html validation errors and warnings

### DIFF
--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.php
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.php
@@ -3,7 +3,7 @@
         <?php if ($attr['options']['size'] == 'invisible' && !isset($attr['options']['callback'])): ?>
             <?php $attr['options']['callback'] = 'onReCaptchaSuccess' ?>
 
-            <script type="text/javascript">
+            <script>
                 var onReCaptchaSuccess = function() {
                     var errorDivs = document.getElementsByClassName('recaptcha-error');
                     if (errorDivs.length) {
@@ -28,7 +28,7 @@
             </script>
         <?php endif ?>
 
-        <script type="text/javascript" src="<?php echo $url_challenge ?>"
+        <script src="<?php echo $url_challenge ?>"
             <?php if (isset($attr['options']['defer']) && $attr['options']['defer']): ?> defer<?php endif ?>
             <?php if (isset($attr['options']['async']) && $attr['options']['async']): ?> async<?php endif ?>
         ></script>
@@ -43,8 +43,7 @@
                 <div style="width: 302px; height: 352px; position: relative;">
                     <div style="width: 302px; height: 352px; position: absolute;">
                         <iframe src="https://<?php echo $ewz_recaptcha_apihost ?>/recaptcha/api/fallback?k=<?php echo $public_key ?>"
-                                frameborder="0" scrolling="no"
-                                style="width: 302px; height:352px; border-style: none;"
+                                style="width: 302px; height:352px; border-style: none; overflow: hidden;"
                         >
                         </iframe>
                     </div>
@@ -61,7 +60,7 @@
     <?php else: ?>
         <div id="ewz_recaptcha_div"></div>
 
-        <script type="text/javascript">
+        <script>
         (function() {
             var script = document.createElement('script');
             script.type = 'text/javascript';

--- a/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/ewz_recaptcha_widget.html.twig
@@ -6,7 +6,7 @@
                 {% set options = attr.options|merge({'callback': 'onReCaptchaSuccess'}) %}
                 {% set attr = attr|merge({'options': options}) %}
 
-                <script type="text/javascript">
+                <script>
                     var onReCaptchaSuccess = function() {
                         var errorDivs = document.getElementsByClassName('recaptcha-error');
                         if (errorDivs.length) {
@@ -31,7 +31,7 @@
                 </script>
             {% endif %}
 
-            <script type="text/javascript" src="{{ form.vars.url_challenge }}"
+            <script src="{{ form.vars.url_challenge }}"
                 {%- if attr.options.defer is defined and attr.options.defer %} defer{% endif -%}
                 {%- if attr.options.async is defined and attr.options.async %} async{% endif -%}
             ></script>
@@ -47,8 +47,7 @@
                     <div style="width: 302px; height: 352px; position: relative;">
                         <div style="width: 302px; height: 352px; position: absolute;">
                             <iframe src="https://{{ form.vars.ewz_recaptcha_apihost }}/recaptcha/api/fallback?k={{ form.vars.public_key }}"
-                                    frameborder="0" scrolling="no"
-                                    style="width: 302px; height:352px; border-style: none;"
+                                    style="width: 302px; height:352px; border-style: none; overflow: hidden;"
                             >
                             </iframe>
                         </div>
@@ -65,7 +64,7 @@
         {% else %}
             <div id="ewz_recaptcha_div"></div>
 
-            <script type="text/javascript">
+            <script>
             (function() {
                 var script = document.createElement('script');
                 script.type = 'text/javascript';


### PR DESCRIPTION
Often in my projects I need a completely valid html code. I think it's inconvenient to override the form theme in every project just to remove obsolete attributes.

This PR fixes the following validation errors and warnings:
![image](https://user-images.githubusercontent.com/28928301/90203527-a8f57b00-dde9-11ea-966a-edf71230c5e9.png)
