### PR TITLE
Fix compatibility to older symfony version

### DIFF
--- a/src/DependencyInjection/EWZRecaptchaExtension.php
+++ b/src/DependencyInjection/EWZRecaptchaExtension.php
@@ -9,7 +9,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -41,10 +40,10 @@ class EWZRecaptchaExtension extends Extension
 
         if (3 == $config['version']) {
             $container->register('ewz_recaptcha.form_builder_factory', EWZRecaptchaV3FormBuilderFactory::class)
-                ->addArgument(new Reference(FormFactoryInterface::class));
+                ->addArgument(new Reference('form.factory'));
         } else {
             $container->register('ewz_recaptcha.form_builder_factory', EWZRecaptchaV2FormBuilderFactory::class)
-                ->addArgument(new Reference(FormFactoryInterface::class));
+                ->addArgument(new Reference('form.factory'));
         }
 
         foreach ($config['service_definition'] as $serviceDefinition) {


### PR DESCRIPTION
The `FormFactoryInterface` is only in newer symfony versions an alias for `form.factory`. Also it recommended in bundles not using symfony interface alias as reference instead the real service name of a symfony service.