### PR TITLE
Fix action name validation

### DIFF
--- a/src/Form/Type/EWZRecaptchaV3Type.php
+++ b/src/Form/Type/EWZRecaptchaV3Type.php
@@ -9,6 +9,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EWZRecaptchaV3Type extends AbstractEWZRecaptchaType
 {
+    public const DEFAULT_ACTION_NAME = 'form';
+
     /** @var bool */
     private $hideBadge;
 

--- a/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
@@ -9,7 +9,7 @@
 
     <script{% if form.vars.script_nonce_csp is defined and form.vars.script_nonce_csp is not same as('') %} nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
       grecaptcha.ready(function () {
-        grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default('form') }}' }).then(function (token) {
+        grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default(constant('EWZ\\Bundle\\RecaptchaBundle\\Form\\Type\\EWZRecaptchaV3Type::DEFAULT_ACTION_NAME')) }}' }).then(function (token) {
           var recaptchaResponse = document.getElementById('{{ id }}');
           recaptchaResponse.value = token;
         });

--- a/src/Validator/Constraints/IsTrueValidatorV3.php
+++ b/src/Validator/Constraints/IsTrueValidatorV3.php
@@ -2,8 +2,10 @@
 
 namespace EWZ\Bundle\RecaptchaBundle\Validator\Constraints;
 
+use EWZ\Bundle\RecaptchaBundle\Form\Type\EWZRecaptchaV3Type;
 use Psr\Log\LoggerInterface;
 use ReCaptcha\ReCaptcha;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -87,11 +89,12 @@ class IsTrueValidatorV3 extends ConstraintValidator
     {
         try {
             $remoteIp = $this->requestStack->getCurrentRequest()->getClientIp();
+            $action = $this->getActionName();
 
             $recaptcha = new ReCaptcha($this->secretKey);
 
             $response = $recaptcha
-                ->setExpectedAction('form')
+                ->setExpectedAction($action)
                 ->setScoreThreshold($this->scoreThreshold)
                 ->verify($token, $remoteIp);
 
@@ -106,5 +109,17 @@ class IsTrueValidatorV3 extends ConstraintValidator
 
             return false;
         }
+    }
+
+    private function getActionName(): string
+    {
+        $object = $this->context->getObject();
+        $action = null;
+
+        if ($object instanceof FormInterface) {
+            $action = $object->getConfig()->getOption('action_name');
+        }
+
+        return $action ?: EWZRecaptchaV3Type::DEFAULT_ACTION_NAME;
     }
 }


### PR DESCRIPTION
This uses the action name specified in the configuration (as shown in the docs).

Fixes #259 