### PR TITLE
Allow to use constraints as PHP 8 attributes

### DIFF
--- a/src/Validator/Constraints/IsTrue.php
+++ b/src/Validator/Constraints/IsTrue.php
@@ -8,11 +8,20 @@ use Symfony\Component\Validator\Constraint;
  * @Annotation
  * @Target("PROPERTY")
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class IsTrue extends Constraint
 {
     public $message = 'This value is not a valid captcha.';
 
     public $invalidHostMessage = 'The captcha was not resolved on the right domain.';
+
+    public function __construct(array $options = null, string $message = null, string invalidHostMessage = null, array $groups = null, $payload = null)
+    {
+        parent::__construct($options ?? [], $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->invalidHostMessage = $invalidHostMessage ?? $this->invalidHostMessage;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Validator/Constraints/IsTrueV3.php
+++ b/src/Validator/Constraints/IsTrueV3.php
@@ -6,6 +6,7 @@ namespace EWZ\Bundle\RecaptchaBundle\Validator\Constraints;
  * @Annotation
  * @Target("PROPERTY")
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class IsTrueV3 extends IsTrue
 {
     /**


### PR DESCRIPTION
This would allow to use these constraints as PHP 8 attributes like https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Validator/Constraints/IsTrue.php#L22 for example.