### PR TITLE
Constraint validator use reCaptcha service for HTTP Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ ewz_recaptcha:
     api_host: recaptcha.net
 ```
 
+You can add HTTP Proxy configuration:
+
+``` yaml
+# app/config/config.yml
+
+ewz_recaptcha:
+    // ...
+    http_proxy:
+        host: proxy.mycompany.com
+        port: 3128
+        auth: proxy_username:proxy_password
+```
+
 #### v2 only Configuration
 
 Sets the default locale:
@@ -117,18 +130,7 @@ ewz_recaptcha:
     // ...
     ajax: true
 ```
-You can add HTTP Proxy configuration:
 
-``` yaml
-# app/config/config.yml
-
-ewz_recaptcha:
-    // ...
-    http_proxy:
-        host: proxy.mycompany.com
-        port: 3128
-        auth: proxy_username:proxy_password
-```
 In case you have turned off the domain name checking on reCAPTCHA's end, you'll need to check the origin of the response by enabling the ``verify_host`` option:
 
 ``` yaml

--- a/src/Extension/ReCaptcha/RequestMethod/ProxyPost.php
+++ b/src/Extension/ReCaptcha/RequestMethod/ProxyPost.php
@@ -67,10 +67,11 @@ class ProxyPost implements RequestMethod
          * PHP 5.6.0 changed the way you specify the peer name for SSL context options.
          * Using "CN_name" will still work, but it will raise deprecated errors.
          */
+        $auth = !empty($this->httpProxy['auth']) ? sprintf('Proxy-Authorization: Basic %s', base64_encode($this->httpProxy['auth'])) : '';
         $peerKey = version_compare(PHP_VERSION, '5.6.0', '<') ? 'CN_name' : 'peer_name';
         $options = array(
             'http' => array(
-                'header' => "Content-type: application/x-www-form-urlencoded\r\n".sprintf('Proxy-Authorization: Basic %s', base64_encode($this->httpProxy['auth'])),
+                'header' => "Content-type: application/x-www-form-urlencoded\r\n".$auth,
                 'method' => 'POST',
                 'content' => $params->toQueryString(),
                 // Force the peer to validate (not needed in 5.6.0+, but still works)

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -70,7 +70,7 @@ services:
         public: true
         arguments:
             - '%ewz_recaptcha.enabled%'
-            - '%ewz_recaptcha.private_key%'
+            - '@ewz_recaptcha.recaptcha'
             - '%ewz_recaptcha.score_threshold%'
             - '@request_stack'
             - '@logger'

--- a/src/Validator/Constraints/IsTrueValidatorV3.php
+++ b/src/Validator/Constraints/IsTrueValidatorV3.php
@@ -16,8 +16,8 @@ class IsTrueValidatorV3 extends ConstraintValidator
     /** @var bool */
     private $enabled;
 
-    /** @var string */
-    private $secretKey;
+    /** @var ReCaptcha */
+    private $recaptcha;
 
     /** @var float */
     private $scoreThreshold;
@@ -32,20 +32,19 @@ class IsTrueValidatorV3 extends ConstraintValidator
      * ContainsRecaptchaValidator constructor.
      *
      * @param bool            $enabled
-     * @param string          $secretKey
      * @param float           $scoreThreshold
      * @param RequestStack    $requestStack
      * @param LoggerInterface $logger
      */
     public function __construct(
         bool $enabled,
-        string $secretKey,
+        ReCaptcha $recaptcha,
         float $scoreThreshold,
         RequestStack $requestStack,
         LoggerInterface $logger
     ) {
         $this->enabled = $enabled;
-        $this->secretKey = $secretKey;
+        $this->recaptcha = $recaptcha;
         $this->scoreThreshold = $scoreThreshold;
         $this->requestStack = $requestStack;
         $this->logger = $logger;
@@ -91,9 +90,7 @@ class IsTrueValidatorV3 extends ConstraintValidator
             $remoteIp = $this->requestStack->getCurrentRequest()->getClientIp();
             $action = $this->getActionName();
 
-            $recaptcha = new ReCaptcha($this->secretKey);
-
-            $response = $recaptcha
+            $response = $this->recaptcha
                 ->setExpectedAction($action)
                 ->setScoreThreshold($this->scoreThreshold)
                 ->verify($token, $remoteIp);


### PR DESCRIPTION
The HTTP Proxy does not work on the v3 validator because the "ReCaptcha" service is not used. So the RequestMethods of the bundle are not used correctly