### PR TITLE
Execute the V3 Challenge on form submit, not on page load

### DIFF
--- a/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
@@ -7,17 +7,24 @@
       <link rel="stylesheet" href="{{ asset('/bundles/ewzrecaptcha/css/recaptcha.css') }}">
     {% endif %}
 
-    <script{% if form.vars.script_nonce_csp is defined and form.vars.script_nonce_csp is not same as('') %} nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
-      grecaptcha.ready(function () {
-        grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default(constant('EWZ\\Bundle\\RecaptchaBundle\\Form\\Type\\EWZRecaptchaV3Type::DEFAULT_ACTION_NAME')) }}' }).then(function (token) {
-          var recaptchaResponse = document.getElementById('{{ id }}');
-          recaptchaResponse.value = token;
-        });
-      });
-    </script>
-
     {{ form_label(form) }}
     {{ form_widget(form) }}
+
+    <script{% if form.vars.script_nonce_csp is defined and form.vars.script_nonce_csp is not same as('') %} nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
+      var grecaptchaInput = document.getElementById('{{ id }}');
+      grecaptchaInput.value = ''; // Always reset the value to get a brand new challenge
+      var grecaptchaForm = grecaptchaInput.form;
+      grecaptchaForm.addEventListener('submit', function (e) {
+        e.preventDefault();
+
+        grecaptcha.ready(function () {
+          grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default(constant('EWZ\\Bundle\\RecaptchaBundle\\Form\\Type\\EWZRecaptchaV3Type::DEFAULT_ACTION_NAME')) }}' }).then(function (token) {
+            grecaptchaInput.value = token;
+            grecaptchaForm.submit();
+          });
+        });
+      }, false);
+    </script>
   {% endif %}
 {% endapply %}
 {% endblock %}


### PR DESCRIPTION
The V3 challenge is often wrong, because you have to submit your form in less than 2 minutes (before the challenge expire).
That's because the challenge is asked too soon.

As per the documentation:

https://developers.google.com/recaptcha/docs/v3

> reCAPTCHA tokens expire after two minutes. If you're protecting an action with reCAPTCHA, make sure to call execute when the user takes the action rather than on page load.

So I changed the JavaScript a bit to call **execute** on form **submit**, not on page load.

Also added this:

```
grecaptchaInput.value = ''; // Always reset the value to get a brand new challenge
```

Because the FormType is keeping the old challenge when the form is submitted with error, and ReCaptcha is not populating a fresh token if there is already one in the field.