### PR TITLE
Define explicit return type

### DIFF
--- a/src/Validator/Constraints/IsTrue.php
+++ b/src/Validator/Constraints/IsTrue.php
@@ -24,7 +24,7 @@ class IsTrue extends Constraint
     }
 
     /**
-     * {@inheritdoc}
+     * @return string|string[]
      */
     public function getTargets()
     {


### PR DESCRIPTION
When using Symfony >= 5.4 if the return type is not explicit, there is a deprecation message:

```
Method "Symfony\Component\Validator\Constraint::getTargets()" might add "string|array" as a native return type declaration in the future. Do the same in child class "EWZ\Bundle\RecaptchaBundle\Validator\Constraints\IsTrue" now to avoid errors or add an explicit @return annotation to suppress this message.
```