### PR TITLE
refactor v3 twig to support multiple recaptcha on the same page, and …

### DIFF
--- a/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
@@ -17,7 +17,12 @@
 
         window['recaptchaOnloadCallback_{{ id }}_done'] = false;
         window['recaptchaOnloadCallback_{{ id }}'] = function() {
-          form.addEventListener('submit', function(e) {
+          addEventListener('submit', function(e) {
+            var element = document.querySelector('#{{ id }}');
+            var form = element.form;
+            if (e.target !== form) {
+              return
+            }
             if (!window['recaptchaOnloadCallback_{{ id }}_done']) {
               e.preventDefault(); // stop form submit
               e.stopPropagation(); // stop also events
@@ -25,6 +30,7 @@
                 element.value = token;
                 window['recaptchaOnloadCallback_{{ id }}_done'] = true;
                 form.querySelector('[type="submit"]').click(); // trigger also events
+                window['recaptchaOnloadCallback_{{ id }}_done'] = false;
               });
             }
           }, true) // execute before other submit listeners

--- a/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
@@ -1,8 +1,6 @@
 {% block ewz_recaptcha_widget %}
 {% apply spaceless %}
   {% if form.vars.ewz_recaptcha_enabled %}
-    <script src="{{ form.vars.ewz_recaptcha_api_uri }}?render={{ form.vars.public_key }}"></script>
-
     {% if form.vars.ewz_recaptcha_hide_badge %}
       <link rel="stylesheet" href="{{ asset('/bundles/ewzrecaptcha/css/recaptcha.css') }}">
     {% endif %}
@@ -11,19 +9,56 @@
     {{ form_widget(form) }}
 
     <script{% if form.vars.script_nonce_csp is defined and form.vars.script_nonce_csp is not same as('') %} nonce="{{ form.vars.script_nonce_csp }}"{% endif %}>
-      var grecaptchaInput = document.getElementById('{{ id }}');
-      grecaptchaInput.value = ''; // Always reset the value to get a brand new challenge
-      var grecaptchaForm = grecaptchaInput.form;
-      grecaptchaForm.addEventListener('submit', function (e) {
-        e.preventDefault();
+      (function(){
+        var element = document.querySelector('#{{ id }}');
+        var form = element.form;
 
-        grecaptcha.ready(function () {
-          grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default(constant('EWZ\\Bundle\\RecaptchaBundle\\Form\\Type\\EWZRecaptchaV3Type::DEFAULT_ACTION_NAME')) }}' }).then(function (token) {
-            grecaptchaInput.value = token;
-            HTMLFormElement.prototype.submit.call(grecaptchaForm);
-          });
-        });
-      }, false);
+        // recaptcha callback for this form
+
+        window['recaptchaOnloadCallback_{{ id }}_done'] = false;
+        window['recaptchaOnloadCallback_{{ id }}'] = function() {
+          form.addEventListener('submit', function(e) {
+            if (!window['recaptchaOnloadCallback_{{ id }}_done']) {
+              e.preventDefault(); // stop form submit
+              e.stopPropagation(); // stop also events
+              grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default(constant('EWZ\\Bundle\\RecaptchaBundle\\Form\\Type\\EWZRecaptchaV3Type::DEFAULT_ACTION_NAME')) }}' }).then(function (token) {
+                element.value = token;
+                window['recaptchaOnloadCallback_{{ id }}_done'] = true;
+                form.querySelector('[type="submit"]').click(); // trigger also events
+              });
+            }
+          }, true) // execute before other submit listeners
+        };
+
+        // recaptcha load for this form
+
+        var loadJS = function () {
+          var script = document.createElement('script');
+          script.type = 'text/javascript';
+          script.src = '{{ form.vars.ewz_recaptcha_api_uri }}?render={{ form.vars.public_key }}&onload=recaptchaOnloadCallback_{{ id }}';
+          script.async = true;
+          document.body.appendChild(script);
+        };
+
+        // detect when form is visible
+
+        if (!('IntersectionObserver' in window) ||
+            !('IntersectionObserverEntry' in window) ||
+            !('intersectionRatio' in window.IntersectionObserverEntry.prototype)) {
+          loadJS();
+        } else {
+          var observer = new IntersectionObserver(function(entries, observer) {
+            entries.forEach(function(entry) {
+              if (entry.intersectionRatio > 0) {
+                observer.disconnect();
+                loadJS();
+              }
+            });
+          }, { root: null });
+
+          observer.observe(form);
+        }
+      })();
     </script>
   {% endif %}
 {% endapply %}

--- a/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
+++ b/src/Resources/views/Form/v3/ewz_recaptcha_widget.html.twig
@@ -29,7 +29,11 @@
               grecaptcha.execute('{{ form.vars.public_key }}', { action: '{{ form.vars.action_name|default(constant('EWZ\\Bundle\\RecaptchaBundle\\Form\\Type\\EWZRecaptchaV3Type::DEFAULT_ACTION_NAME')) }}' }).then(function (token) {
                 element.value = token;
                 window['recaptchaOnloadCallback_{{ id }}_done'] = true;
-                form.querySelector('[type="submit"]').click(); // trigger also events
+                if (e.submitter) {
+                  e.submitter.click(); // trigger also events
+                } else {
+                  form.submit();
+                }
                 window['recaptchaOnloadCallback_{{ id }}_done'] = false;
               });
             }


### PR DESCRIPTION
Hello, i've forked this plugin in our webgriffe projects, and with many iterations this is the final version of the recaptcha v3 we could come to.

It has different features:

- it supports multiple recaptcha on the same page
- it loads the recaptcha js only if the form is visible (not `display: none`) useful for pagespeed if you have the recaptcha on all pages inside modal for exampl
- it if the recaptcha form has a custom `submit` `addEventListener`, it prevents also them, and it calls them triggering click on the submit button instead of `form.submit()` which doesn't trigger `submit` listeners