### PR TITLE
Make ReCaptcha service lazy

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -35,6 +35,7 @@ services:
     ewz_recaptcha.recaptcha:
         class: ReCaptcha\ReCaptcha
         public: false
+        lazy: true
         arguments:
             - '%ewz_recaptcha.private_key%'
             - '@ewz_recaptcha.extension.recaptcha.request_method.post'


### PR DESCRIPTION
As described in #252 ReCaptcha service is required by IsTrue constraint even if the reCAPTCHA is disabled. I suggest to make ReCaptcha service lazy to avoid initialization in case of disabled reCAPTCHA.

