### PR TITLE
feat: drop support of php 7.1, drop support of symfony < 4.4, …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.1, 7.2, 7.3, 7.4, 8.0, 8.1]
-        symfony: [2.8, 3.4, 4.4, 5.2, 6.0]
+        php: [ 7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        symfony: [4.4, 5.4, 6.0]
         exclude:
-          - php: 7.1
-            symfony: 5.2
           - php: 8.0
             symfony: 3.4
-          - php: 7.1
-            symfony: 6.0
           - php: 7.2
             symfony: 6.0
           - php: 7.3
@@ -31,7 +27,7 @@ jobs:
             symfony: 6.0
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -41,10 +37,10 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
         php: [ 7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
         symfony: [4.4, 5.4, 6.0]
         exclude:
-          - php: 8.0
-            symfony: 3.4
           - php: 7.2
             symfony: 6.0
           - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,17 @@
     }
   ],
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.2 || ^8.0",
     "google/recaptcha": "^1.1",
-    "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/yaml": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
+    "symfony/form": "^4.4 || ^5.0 || ^6.0",
+    "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
+    "symfony/security-bundle": "^4.4 || ^5.0 || ^6.0",
+    "symfony/validator": "^4.4 || ^5.0 || ^6.0",
+    "symfony/yaml": "^4.4 || ^5.0 || ^6.0",
     "twig/twig": "^1.40 || ^2.9 || ^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7 || ^8 || ^9.5"
+    "phpunit/phpunit": "^8.5 || ^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
-         colors="true">
+         colors="true"
+>
+
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
 
   <testsuites>
     <testsuite name="EWZRecaptchaBundle">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist>
-      <directory suffix=".php">src</directory>
-    </whitelist>
-  </filter>
 
 </phpunit>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,12 +18,7 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('ewz_recaptcha');
 
-        if (method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('ewz_recaptcha');
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()
@@ -51,7 +46,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    private function addHttpClientConfiguration(ArrayNodeDefinition $node)
+    private function addHttpClientConfiguration(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -67,7 +62,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addServiceDefinitionConfiguration(ArrayNodeDefinition $node)
+    private function addServiceDefinitionConfiguration(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/src/DependencyInjection/EWZRecaptchaExtension.php
+++ b/src/DependencyInjection/EWZRecaptchaExtension.php
@@ -58,8 +58,6 @@ class EWZRecaptchaExtension extends Extension
 
     /**
      * Registers the form widget.
-     *
-     * @param ContainerBuilder $container
      */
     protected function registerWidget(ContainerBuilder $container, int $version = 2): void
     {

--- a/src/Validator/Constraints/IsTrueValidatorV3.php
+++ b/src/Validator/Constraints/IsTrueValidatorV3.php
@@ -29,6 +29,11 @@ class IsTrueValidatorV3 extends ConstraintValidator
     private $logger;
 
     /**
+     * @var ReCaptcha
+     */
+    private $reCaptcha;
+
+    /**
      * ContainsRecaptchaValidator constructor.
      *
      * @param bool            $enabled


### PR DESCRIPTION
improve ci, migrate phpunit config, fix for php 8.2

ci deprecation:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/