### PR TITLE
Allow using the IsTrue validator against a simple form field

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
   "require": {
     "php": "^7.1 || ^8.0",
     "google/recaptcha": "^1.1",
-    "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
-    "symfony/yaml": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0",
+    "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/security-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/validator": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
+    "symfony/yaml": "^2.8 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
     "twig/twig": "^1.40 || ^2.9 || ^3.0"
   },
   "require-dev": {

--- a/src/Validator/Constraints/IsTrueValidator.php
+++ b/src/Validator/Constraints/IsTrueValidator.php
@@ -102,7 +102,7 @@ class IsTrueValidator extends ConstraintValidator
 
         $remoteip = $request->getClientIp();
         // define variable for recaptcha check answer
-        $answer = $request->get('g-recaptcha-response');
+        $answer = $request->get('g-recaptcha-response', $value);
 
         // Verify user response with Google
         $response = $this->recaptcha->verify($answer, $remoteip);


### PR DESCRIPTION
By defaulting to the field value, we allow IsTrue validation against any form field, without hardcoded field name "g-recaptcha-response" in the request.

This is useful for example:
- when the "g-recaptcha-response" field cannot be sent with our request (neither through query string, or post, etc);
- when a custom widget is rendering the field, the name of such field cannot be (or should not be) controlled;
- when using third party UIs that support Symfony Forms and Validation but don't allow setting an out of scope variable to be sent to the server.

Example:

```php
$builder->add('_captcha', CaptchaType::class, [
  'required' => true,
  'constraints' => [
    new NotNull(),
    new IsTrue(), // verification token will be sent as "_captcha"
  ],
]);
```