### PR TITLE
Add nullable types on isTrue construct params

### DIFF
--- a/src/Validator/Constraints/IsTrue.php
+++ b/src/Validator/Constraints/IsTrue.php
@@ -15,7 +15,7 @@ class IsTrue extends Constraint
 
     public $invalidHostMessage = 'The captcha was not resolved on the right domain.';
 
-    public function __construct(array $options = null, string $message = null, string $invalidHostMessage = null, array $groups = null, $payload = null)
+    public function __construct(?array $options = null, ?string $message = null, ?string $invalidHostMessage = null, ?array $groups = null, mixed $payload = null)
     {
         parent::__construct($options ?? [], $groups, $payload);
 


### PR DESCRIPTION
This PR allows to fix warning because with php 8.4, we need to add ? type on nullable params.